### PR TITLE
Add Network Layer for Lobby (REST + WebSocket)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
             ${project.build.directory}/site/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.coverage.exclusions>
-            **/DoomHamstersApplication.java
+            **/DoomHamstersApplication.java,
+            **/HelloController.java
         </sonar.coverage.exclusions>
     </properties>
 
@@ -144,6 +145,7 @@
                         <configuration>
                             <excludes>
                                 <exclude>com/doomhamsters/DoomHamstersApplication.class</exclude>
+                                <exclude>com/doomhamsters/controller/HelloController.class</exclude>
                             </excludes>
                             <rules>
                                 <rule>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>4.8.6.4</version>
+                <configuration>
+                    <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+        https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+  <!--
+    SimpMessagingTemplate is a Spring-managed singleton injected by the framework.
+    Defensive copying is neither possible nor meaningful for framework beans.
+  -->
+  <Match>
+    <Class name="com.doomhamsters.lobby.LobbyController"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+</FindBugsFilter>

--- a/src/main/java/com/doomhamsters/config/WebSocketConfig.java
+++ b/src/main/java/com/doomhamsters/config/WebSocketConfig.java
@@ -6,6 +6,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+/** Configures STOMP over WebSocket for real-time lobby and game communication. */
 @Configuration
 @EnableWebSocketMessageBroker
 @SuppressWarnings("PMD.AtLeastOneConstructor")

--- a/src/main/java/com/doomhamsters/config/WebSocketConfig.java
+++ b/src/main/java/com/doomhamsters/config/WebSocketConfig.java
@@ -1,0 +1,37 @@
+package com.doomhamsters.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  /**
+   * Sets up the in-memory message broker.
+   *
+   * <p>/topic — broadcast to all subscribers (e.g. game-state updates)<br>
+   * /queue — messages directed to a single client (e.g. private hand)<br>
+   * /app — prefix clients use to send messages to @MessageMapping handlers
+   */
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    config.enableSimpleBroker("/topic", "/queue");
+    config.setApplicationDestinationPrefixes("/app");
+  }
+
+  /**
+   * Registers the WebSocket handshake endpoint.
+   *
+   * <p>Clients connect to ws://localhost:53217/ws
+   * Android client uses Krossbow with native soch
+   */
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+  }
+}

--- a/src/main/java/com/doomhamsters/controller/HelloController.java
+++ b/src/main/java/com/doomhamsters/controller/HelloController.java
@@ -4,7 +4,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 
-/** Ping Pong Test*/
+/** Ping Pong Test. */
 @Controller
 @SuppressWarnings("PMD.AtLeastOneConstructor")
 public class HelloController {

--- a/src/main/java/com/doomhamsters/controller/HelloController.java
+++ b/src/main/java/com/doomhamsters/controller/HelloController.java
@@ -1,0 +1,24 @@
+package com.doomhamsters.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+/** Ping Pong Test*/
+@Controller
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class HelloController {
+
+  /**
+   * Receives a text message on {/app/hello} and broadcasts the reply to
+   * every subscriber of {/topic/test}.
+   *
+   * @param message the raw text sent by the client
+   * @return a plain confirmation string broadcast to {@code /topic/test}
+   */
+  @MessageMapping("/hello")
+  @SendTo("/topic/test")
+  public String handleHello(String message) {
+    return "[BACKEND]: Hello App!" + "\nI received from you the following text: [APP]: " + message;
+  }
+}

--- a/src/main/java/com/doomhamsters/lobby/CreateLobbyRequest.java
+++ b/src/main/java/com/doomhamsters/lobby/CreateLobbyRequest.java
@@ -1,0 +1,28 @@
+package com.doomhamsters.lobby;
+
+/** DTO for the create-lobby REST request. */
+public class CreateLobbyRequest {
+
+  private String groupName;
+  private User user;
+
+  public CreateLobbyRequest() {}
+
+  public String getGroupName() {
+    return groupName;
+  }
+
+  public void setGroupName(String groupName) {
+    this.groupName = groupName;
+  }
+
+  // Defensive copy – avoids EI_EXPOSE_REP (User is mutable)
+  public User getUser() {
+    return user == null ? null : new User(user.getId(), user.getUsername(), user.getAvatar());
+  }
+
+  // Defensive copy – avoids EI_EXPOSE_REP2
+  public void setUser(User user) {
+    this.user = user == null ? null : new User(user.getId(), user.getUsername(), user.getAvatar());
+  }
+}

--- a/src/main/java/com/doomhamsters/lobby/LobbyController.java
+++ b/src/main/java/com/doomhamsters/lobby/LobbyController.java
@@ -1,0 +1,81 @@
+package com.doomhamsters.lobby;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoints for lobby management.
+ *
+ * <p>Create/join use HTTP request-response. After a join the updated lobby is
+ * also broadcast via STOMP so all connected clients see the new member.
+ */
+@RestController
+@RequestMapping("/api/lobby")
+public class LobbyController {
+
+  private final LobbyService lobbyService;
+  private final SimpMessagingTemplate messagingTemplate;
+
+  /** Constructs the controller with its dependencies. */
+  public LobbyController(LobbyService lobbyService, SimpMessagingTemplate messagingTemplate) {
+    this.lobbyService = lobbyService;
+    this.messagingTemplate = messagingTemplate;
+  }
+
+  /**
+   * Creates a new lobby and returns it.
+   *
+   * <p>POST /api/lobby/create
+   *
+   * @param request body containing {@code groupName} and the creator {@code user}
+   * @return the created lobby with generated QR code
+   */
+  @PostMapping("/create")
+  public ResponseEntity<Lobby> createLobby(@RequestBody CreateLobbyRequest request) {
+    Lobby lobby = lobbyService.createLobby(request.getGroupName(), request.getUser());
+    return ResponseEntity.ok(lobby);
+  }
+
+  /**
+   * Adds a user to an existing lobby and broadcasts the updated lobby to all subscribers.
+   *
+   * <p>POST /api/lobby/{lobbyId}/join
+   *
+   * @param lobbyId the target lobby identifier
+   * @param user the joining player
+   * @return updated lobby, or 404 if the lobby does not exist
+   */
+  @PostMapping("/{lobbyId}/join")
+  public ResponseEntity<Lobby> joinLobby(
+      @PathVariable String lobbyId, @RequestBody User user) {
+    return lobbyService
+        .joinOrUpdateLobby(lobbyId, user)
+        .map(
+            lobby -> {
+              // Broadcast to all clients subscribed to this lobby
+              messagingTemplate.convertAndSend("/topic/lobby/" + lobbyId, lobby);
+              return ResponseEntity.ok(lobby);
+            })
+        .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  /**
+   * Returns the current state of a lobby.
+   *
+   * <p>GET /api/lobby/{lobbyId}
+   *
+   * @param lobbyId the target lobby identifier
+   * @return lobby state, or 404 if not found
+   */
+  @GetMapping("/{lobbyId}")
+  public ResponseEntity<Lobby> getLobby(@PathVariable String lobbyId) {
+    Lobby lobby = lobbyService.getLobby(lobbyId);
+    return lobby != null ? ResponseEntity.ok(lobby) : ResponseEntity.notFound().build();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=DoomHamsters
+server.port=53217

--- a/src/test/java/com/doomhamsters/lobby/CreateLobbyRequestTest.java
+++ b/src/test/java/com/doomhamsters/lobby/CreateLobbyRequestTest.java
@@ -1,0 +1,39 @@
+package com.doomhamsters.lobby;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for the CreateLobbyRequest DTO. */
+class CreateLobbyRequestTest {
+
+  @Test
+  void testDefaultConstructorReturnsNulls() {
+    CreateLobbyRequest request = new CreateLobbyRequest();
+
+    assertNull(request.getGroupName());
+    assertNull(request.getUser());
+  }
+
+  @Test
+  void testSettersAndGetters() {
+    CreateLobbyRequest request = new CreateLobbyRequest();
+    User user = new User("u1", "Hamster", "🐹");
+
+    request.setGroupName("MyLobby");
+    request.setUser(user);
+
+    assertEquals("MyLobby", request.getGroupName());
+    assertEquals(user, request.getUser());
+  }
+
+  @Test
+  void testGroupNameCanBeUpdated() {
+    CreateLobbyRequest request = new CreateLobbyRequest();
+    request.setGroupName("First");
+    request.setGroupName("Second");
+
+    assertEquals("Second", request.getGroupName());
+  }
+}

--- a/src/test/java/com/doomhamsters/lobby/LobbyControllerTest.java
+++ b/src/test/java/com/doomhamsters/lobby/LobbyControllerTest.java
@@ -1,0 +1,134 @@
+package com.doomhamsters.lobby;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+/**
+ * Unit tests for LobbyController.
+ * Mocks LobbyService and SimpMessagingTemplate to isolate controller logic.
+ */
+class LobbyControllerTest {
+
+  private LobbyService lobbyService;
+  private SimpMessagingTemplate messagingTemplate;
+  private LobbyController controller;
+
+  private User testUser;
+  private Lobby testLobby;
+
+  @BeforeEach
+  void setUp() {
+    lobbyService = mock(LobbyService.class);
+    messagingTemplate = mock(SimpMessagingTemplate.class);
+    controller = new LobbyController(lobbyService, messagingTemplate);
+
+    testUser = new User("u1", "HamsterPro", "🐹");
+    testLobby = new Lobby("TEST");
+    testLobby.setMembers(List.of(testUser));
+    testLobby.setQrCodeBase64("base64qr==");
+  }
+
+  // ── createLobby ──────────────────────────────────────────────────────────
+
+  @Test
+  void createLobby_returnsOkWithLobby() {
+    CreateLobbyRequest request = new CreateLobbyRequest();
+    request.setGroupName("Test");
+    request.setUser(testUser);
+    when(lobbyService.createLobby("Test", testUser)).thenReturn(testLobby);
+
+    ResponseEntity<Lobby> response = controller.createLobby(request);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals("TEST", response.getBody().getLobbyId());
+  }
+
+  @Test
+  void createLobby_returnsLobbyWithMembers() {
+    CreateLobbyRequest request = new CreateLobbyRequest();
+    request.setGroupName("Test");
+    request.setUser(testUser);
+    when(lobbyService.createLobby(any(), any())).thenReturn(testLobby);
+
+    ResponseEntity<Lobby> response = controller.createLobby(request);
+
+    assertEquals(1, response.getBody().getMembers().size());
+    assertEquals("HamsterPro", response.getBody().getMembers().get(0).getUsername());
+  }
+
+  // ── joinLobby ─────────────────────────────────────────────────────────────
+
+  @Test
+  void joinLobby_returnsOkAndBroadcastsWhenLobbyExists() {
+    User joiningUser = new User("u2", "Gast", "🐱");
+    Lobby updatedLobby = new Lobby("TEST");
+    updatedLobby.setMembers(List.of(testUser, joiningUser));
+    when(lobbyService.joinOrUpdateLobby("TEST", joiningUser))
+        .thenReturn(Optional.of(updatedLobby));
+
+    ResponseEntity<Lobby> response = controller.joinLobby("TEST", joiningUser);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(2, response.getBody().getMembers().size());
+    verify(messagingTemplate).convertAndSend(eq("/topic/lobby/TEST"), any(Lobby.class));
+  }
+
+  @Test
+  void joinLobby_returns404WhenLobbyNotFound() {
+    when(lobbyService.joinOrUpdateLobby(anyString(), any())).thenReturn(Optional.empty());
+
+    ResponseEntity<Lobby> response = controller.joinLobby("DOES_NOT_EXIST", testUser);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+  }
+
+  @Test
+  void joinLobby_broadcastsToCorrectTopic() {
+    User joiner = new User("u3", "NewPlayer", "🦊");
+    Lobby updated = new Lobby("ROOM_42");
+    updated.setMembers(List.of(joiner));
+    when(lobbyService.joinOrUpdateLobby("ROOM_42", joiner)).thenReturn(Optional.of(updated));
+
+    controller.joinLobby("ROOM_42", joiner);
+
+    verify(messagingTemplate).convertAndSend("/topic/lobby/ROOM_42", updated);
+  }
+
+  // ── getLobby Status ──────────────────────────────────────────────────────────────
+
+  @Test
+  void getLobby_returnsOkWithLobbyWhenFound() {
+    when(lobbyService.getLobby("TEST")).thenReturn(testLobby);
+
+    ResponseEntity<Lobby> response = controller.getLobby("TEST");
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("TEST", response.getBody().getLobbyId());
+  }
+
+  @Test
+  void getLobby_returns404WhenNotFound() {
+    when(lobbyService.getLobby("MISSING")).thenReturn(null);
+
+    ResponseEntity<Lobby> response = controller.getLobby("MISSING");
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+  }
+}


### PR DESCRIPTION
- Add LobbyController with REST endpoints for creating, joining, and fetching a lobby; 
- Add CreateLobbyRequest DTO; 
- Add unit tests for LobbyController, CreateLobbyRequest. 
