### PR TITLE
Game state recovery (#27,#28)

### DIFF
--- a/src/main/java/com/doomhamsters/Board.java
+++ b/src/main/java/com/doomhamsters/Board.java
@@ -26,6 +26,17 @@ public class Board {
     this.discardPile = new ArrayList<>();
   }
 
+  public Board(Board other, List<Player> players, Deck deck) {
+    this.players = players;
+    this.deck = deck;
+    this.currentIndex = other.currentIndex;
+
+    this.discardPile = new ArrayList<>();
+    for (Card card : other.discardPile) {
+      this.discardPile.add(new Card(card));
+    }
+  }
+
   public Player getCurrentPlayer() {
     return players.get(currentIndex);
   }

--- a/src/main/java/com/doomhamsters/Board.java
+++ b/src/main/java/com/doomhamsters/Board.java
@@ -34,8 +34,8 @@ public class Board {
    * @param deck the copied deck to use
    */
   public Board(Board other, List<Player> players, Deck deck) {
-    this.players = players;
-    this.deck = deck;
+    this.players = new ArrayList<>(players);
+    this.deck = new Deck(deck);
     this.currentIndex = other.currentIndex;
 
     this.discardPile = new ArrayList<>();

--- a/src/main/java/com/doomhamsters/Board.java
+++ b/src/main/java/com/doomhamsters/Board.java
@@ -26,6 +26,13 @@ public class Board {
     this.discardPile = new ArrayList<>();
   }
 
+  /**
+   * Creates a deep copy of another board.
+   *
+   * @param other the board to copy
+   * @param players the copied players to use
+   * @param deck the copied deck to use
+   */
   public Board(Board other, List<Player> players, Deck deck) {
     this.players = players;
     this.deck = deck;

--- a/src/main/java/com/doomhamsters/Card.java
+++ b/src/main/java/com/doomhamsters/Card.java
@@ -30,6 +30,13 @@ public class Card {
     this.effect = effect;
   }
 
+  public Card(Card other) {
+    this.id = other.id;
+    this.name = other.name;
+    this.type = other.type;
+    this.effect = other.effect;
+  }
+
   /**
    * Creates a card without an effect.
    *

--- a/src/main/java/com/doomhamsters/Card.java
+++ b/src/main/java/com/doomhamsters/Card.java
@@ -30,6 +30,11 @@ public class Card {
     this.effect = effect;
   }
 
+  /**
+   * Creates a copy of another card.
+   *
+   * @param other the card to copy
+   */
   public Card(Card other) {
     this.id = other.id;
     this.name = other.name;

--- a/src/main/java/com/doomhamsters/Deck.java
+++ b/src/main/java/com/doomhamsters/Deck.java
@@ -19,6 +19,18 @@ public class Deck {
     this.cards = new ArrayList<>(cards);
     this.discards = new ArrayList<>();
   }
+
+  public Deck(Deck other) {
+    this.cards = new ArrayList<>();
+    this.discards = new ArrayList<>();
+
+    for (Card card : other.cards) {
+      this.cards.add(new Card(card));
+    }
+    for (Card card : other.discards) {
+      this.cards.add(new Card(card));
+    }
+  }
   /**
    * Default constructor.
    */

--- a/src/main/java/com/doomhamsters/Deck.java
+++ b/src/main/java/com/doomhamsters/Deck.java
@@ -20,6 +20,11 @@ public class Deck {
     this.discards = new ArrayList<>();
   }
 
+  /**
+   * Creates a deep copy of another deck.
+   *
+   * @param other the deck to copy
+   */
   public Deck(Deck other) {
     this.cards = new ArrayList<>();
     this.discards = new ArrayList<>();
@@ -27,8 +32,9 @@ public class Deck {
     for (Card card : other.cards) {
       this.cards.add(new Card(card));
     }
+
     for (Card card : other.discards) {
-      this.cards.add(new Card(card));
+      this.discards.add(new Card(card));
     }
   }
   /**

--- a/src/main/java/com/doomhamsters/Game.java
+++ b/src/main/java/com/doomhamsters/Game.java
@@ -34,6 +34,36 @@ public class Game {
   }
 
   /**
+   * Creates a deep copy of another game instance.
+   *
+   * @param other the game to copy
+   */
+  public Game(Game other) {
+    this.state = other.state;
+    this.random.setSeed(System.currentTimeMillis());
+
+    this.players = new ArrayList<>();
+    for (Player player : other.players) {
+      this.players.add(new Player(player));
+    }
+
+    this.winner =
+        other.winner == null
+            ? null
+            : this.players.stream()
+                .filter(p -> p.getId().equals(other.winner.getId()))
+                .findFirst()
+                .orElse(null);
+
+    this.deck = other.deck == null ? null : new Deck(other.deck);
+
+    this.board =
+        other.board == null
+            ? null
+            : new Board(other.board, this.players, this.deck);
+  }
+
+  /**
    * Returns the current state of the game.
    *
    * @return the current {@link State}

--- a/src/main/java/com/doomhamsters/Game.java
+++ b/src/main/java/com/doomhamsters/Game.java
@@ -40,7 +40,6 @@ public class Game {
    */
   public Game(Game other) {
     this.state = other.state;
-    this.random.setSeed(System.currentTimeMillis());
 
     this.players = new ArrayList<>();
     for (Player player : other.players) {

--- a/src/main/java/com/doomhamsters/Player.java
+++ b/src/main/java/com/doomhamsters/Player.java
@@ -29,6 +29,17 @@ public class Player {
     this.eliminated = false;
   }
 
+  public Player(Player other) {
+    this.id = other.id;
+    this.name = other.name;
+    this.lives = other.lives;
+
+    this.hand = new ArrayList<>();
+    for (Card card : other.hand) {
+      this.hand.add(new Card(card));
+    }
+  }
+
   public String getId() {
     return id;
   }

--- a/src/main/java/com/doomhamsters/Player.java
+++ b/src/main/java/com/doomhamsters/Player.java
@@ -29,6 +29,11 @@ public class Player {
     this.eliminated = false;
   }
 
+  /**
+   * Creates a deep copy of another player.
+   *
+   * @param other the player to copy
+   */
   public Player(Player other) {
     this.id = other.id;
     this.name = other.name;

--- a/src/main/java/com/doomhamsters/gamesession/GameSession.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSession.java
@@ -84,7 +84,9 @@ public class GameSession {
    * @param game the game instance
    */
   public void setGame(Game game) {
-    this.game = game;
+    this.game = game == null
+        ? null
+        : new Game(game);
   }
 
   /**

--- a/src/main/java/com/doomhamsters/gamesession/GameSession.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSession.java
@@ -7,15 +7,22 @@ import org.apache.logging.log4j.internal.annotation.SuppressFBWarnings;
  * Represents a single game session and its current state.
  */
 public class GameSession {
-  private final String gameId;
-  private final String lobbyId;
-  private final Game game;
+
+  private String gameId;
+  private String lobbyId;
+  private Game game;
   private GameStatus status;
+
+  /**
+   * Empty constructor required for JSON deserialization.
+   */
+  public GameSession() {
+  }
 
   /**
    * Constructs a new GameSession.
    *
-   * @param gameId  the unique identifier for the game
+   * @param gameId the unique identifier for the game
    * @param lobbyId the identifier of the lobby this game started from
    */
   public GameSession(String gameId, String lobbyId) {
@@ -35,6 +42,15 @@ public class GameSession {
   }
 
   /**
+   * Sets the game ID.
+   *
+   * @param gameId the game ID
+   */
+  public void setGameId(String gameId) {
+    this.gameId = gameId;
+  }
+
+  /**
    * Gets the lobby ID.
    *
    * @return the lobby ID
@@ -44,13 +60,31 @@ public class GameSession {
   }
 
   /**
+   * Sets the lobby ID.
+   *
+   * @param lobbyId the lobby ID
+   */
+  public void setLobbyId(String lobbyId) {
+    this.lobbyId = lobbyId;
+  }
+
+  /**
    * Gets the internal game logic instance.
    *
-   * @return the game instance (never null)
+   * @return the game instance
    */
   @SuppressFBWarnings("EI_EXPOSE_REP")
   public Game getGame() {
     return game;
+  }
+
+  /**
+   * Sets the game instance.
+   *
+   * @param game the game instance
+   */
+  public void setGame(Game game) {
+    this.game = game;
   }
 
   /**
@@ -75,6 +109,8 @@ public class GameSession {
    * Possible states for a game session.
    */
   public enum GameStatus {
-    SETUP, RUNNING, FINISHED
+    SETUP,
+    RUNNING,
+    FINISHED
   }
 }

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
@@ -1,0 +1,53 @@
+package com.doomhamsters.gamesession;
+
+import java.io.File;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Handles persistence of game sessions to disk.
+ */
+@Service
+public class GameSessionPersistenceService {
+
+  private static final String FILE_PATH = "sessions.json";
+
+  private final ObjectMapper objectMapper;
+
+  public GameSessionPersistenceService() {
+    this.objectMapper = new ObjectMapper();
+  }
+
+  /**
+   * Saves all sessions to disk.
+   *
+   * @param sessions all active sessions
+   */
+  public void saveSessions(ConcurrentHashMap<String, GameSession> sessions) {
+
+    objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValue(new File(FILE_PATH), sessions);
+
+  }
+
+  /**
+   * Loads sessions from disk.
+   *
+   * @return restored sessions or empty map if file does not exist
+   */
+  public ConcurrentHashMap<String, GameSession> loadSessions() {
+
+    File file = new File(FILE_PATH);
+
+    if (!file.exists()) {
+      return new ConcurrentHashMap<>();
+    }
+
+    return objectMapper.readValue(
+        file,
+        new TypeReference<ConcurrentHashMap<String, GameSession>>() {});
+
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionService.java
@@ -11,7 +11,21 @@ import org.springframework.stereotype.Service;
 @Service
 public class GameSessionService {
 
-  private final ConcurrentHashMap<String, GameSession> sessions = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, GameSession> sessions;
+
+  private final GameSessionPersistenceService persistenceService;
+
+  /**
+   * Constructs the service and restores persisted sessions.
+   *
+   * @param persistenceService persistence handler
+   */
+  public GameSessionService(GameSessionPersistenceService persistenceService) {
+
+    this.persistenceService = persistenceService;
+
+    this.sessions = persistenceService.loadSessions();
+  }
 
   /**
    * Creates and stores a new game session for a given lobby.
@@ -20,9 +34,15 @@ public class GameSessionService {
    * @return the newly created session
    */
   public GameSession createSession(String lobbyId) {
+
     String gameId = UUID.randomUUID().toString();
+
     GameSession newSession = new GameSession(gameId, lobbyId);
+
     sessions.put(gameId, newSession);
+
+    persistSessions();
+
     return newSession;
   }
 
@@ -33,6 +53,7 @@ public class GameSessionService {
    * @return an Optional containing the session if found
    */
   public Optional<GameSession> getSession(String gameId) {
+
     return Optional.ofNullable(sessions.get(gameId));
   }
 
@@ -42,6 +63,17 @@ public class GameSessionService {
    * @param session the session to save
    */
   public void saveSession(GameSession session) {
+
     sessions.put(session.getGameId(), session);
+
+    persistSessions();
+  }
+
+  /**
+   * Persists all active sessions to disk.
+   */
+  private void persistSessions() {
+
+    persistenceService.saveSessions(sessions);
   }
 }

--- a/src/main/java/com/doomhamsters/gamesession/dto/CardDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/CardDto.java
@@ -1,0 +1,40 @@
+package com.doomhamsters.gamesession.dto;
+
+/**
+ * DTO representing a visible card.
+ */
+public class CardDto {
+
+  private String id;
+
+  private String name;
+
+  private String type;
+
+  public CardDto() {
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/dto/GameStateController.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/GameStateController.java
@@ -1,0 +1,65 @@
+package com.doomhamsters.gamesession.dto;
+
+import com.doomhamsters.gamesession.GameSessionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoints for game state recovery and reconnects.
+ */
+@RestController
+@RequestMapping("/api/game")
+public class GameStateController {
+
+  private final GameSessionService gameSessionService;
+
+  private final GameStateMapper gameStateMapper;
+
+  /**
+   * Constructs the controller with dependencies.
+   *
+   * @param gameSessionService session service
+   * @param gameStateMapper DTO mapper
+   */
+  public GameStateController(
+      GameSessionService gameSessionService,
+      GameStateMapper gameStateMapper) {
+
+    this.gameSessionService = gameSessionService;
+    this.gameStateMapper = gameStateMapper;
+  }
+
+  /**
+   * Returns the current filtered game state for a reconnecting player.
+   *
+   * <p>Other players' hands are hidden.
+   *
+   * <p>GET /api/game/{gameId}/state?playerId=...
+   *
+   * @param gameId the target game session
+   * @param playerId the reconnecting player
+   * @return filtered game state
+   */
+  @GetMapping("/{gameId}/state")
+  public ResponseEntity<GameStateDto> getGameState(
+      @PathVariable String gameId,
+      @RequestParam String playerId) {
+
+    return gameSessionService
+        .getSession(gameId)
+        .map(session -> {
+
+          GameStateDto dto =
+              gameStateMapper.toFilteredDto(
+                  session,
+                  playerId);
+
+          return ResponseEntity.ok(dto);
+        })
+        .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/dto/GameStateDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/GameStateDto.java
@@ -1,0 +1,65 @@
+package com.doomhamsters.gamesession.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * DTO representing the visible game state for a client.
+ */
+public class GameStateDto {
+
+  private String gameId;
+
+  private String gameState;
+
+  private String currentPlayerId;
+
+  private int turnCount;
+
+  private List<PlayerStateDto> players = new ArrayList<>();
+
+  public GameStateDto() {
+  }
+
+  public String getGameId() {
+    return gameId;
+  }
+
+  public void setGameId(String gameId) {
+    this.gameId = gameId;
+  }
+
+  public String getGameState() {
+    return gameState;
+  }
+
+  public void setGameState(String gameState) {
+    this.gameState = gameState;
+  }
+
+  public String getCurrentPlayerId() {
+    return currentPlayerId;
+  }
+
+  public void setCurrentPlayerId(String currentPlayerId) {
+    this.currentPlayerId = currentPlayerId;
+  }
+
+  public int getTurnCount() {
+    return turnCount;
+  }
+
+  public void setTurnCount(int turnCount) {
+    this.turnCount = turnCount;
+  }
+
+  public List<PlayerStateDto> getPlayers() {
+    return new ArrayList<>(players);
+  }
+
+  public void setPlayers(List<PlayerStateDto> players) {
+    this.players = players == null
+        ? new ArrayList<>()
+        : new ArrayList<>(players);
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/dto/GameStateDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/GameStateDto.java
@@ -57,6 +57,11 @@ public class GameStateDto {
     return new ArrayList<>(players);
   }
 
+  /**
+   * Sets the visible players in the game state.
+   *
+   * @param players the player DTO list
+   */
   public void setPlayers(List<PlayerStateDto> players) {
     this.players = players == null
         ? new ArrayList<>()

--- a/src/main/java/com/doomhamsters/gamesession/dto/GameStateMapper.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/GameStateMapper.java
@@ -1,0 +1,87 @@
+package com.doomhamsters.gamesession.dto;
+
+import com.doomhamsters.Card;
+import com.doomhamsters.Game;
+import com.doomhamsters.Player;
+import com.doomhamsters.gamesession.GameSession;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps internal game sessions to filtered DTOs for clients.
+ */
+@Component
+public class GameStateMapper {
+
+  /**
+   * Creates a filtered game state DTO for a specific player.
+   *
+   * <p>Other players' hands are hidden.
+   *
+   * @param session the current game session
+   * @param requestingPlayerId the player requesting the state
+   * @return filtered game state DTO
+   */
+  public GameStateDto toFilteredDto(
+      GameSession session,
+      String requestingPlayerId) {
+
+    Game game = session.getGame();
+
+    GameStateDto dto = new GameStateDto();
+
+    dto.setGameId(session.getGameId());
+    dto.setGameState(game.getState().name());
+
+    if (game.getBoard() != null
+        && game.getBoard().getCurrentPlayer() != null) {
+
+      dto.setCurrentPlayerId(
+          game.getBoard().getCurrentPlayer().getId());
+
+      dto.setTurnCount(
+          game.getBoard().getTurnCount());
+    }
+
+    List<PlayerStateDto> playerDtos = new ArrayList<>();
+
+    for (Player player : game.getPlayers()) {
+
+      PlayerStateDto playerDto = new PlayerStateDto();
+
+      playerDto.setPlayerId(player.getId());
+      playerDto.setPlayerName(player.getName());
+      playerDto.setLives(player.getLives());
+      playerDto.setAlive(player.isAlive());
+      playerDto.setHandSize(player.getHand().size());
+
+      boolean isRequestingPlayer =
+          player.getId().equals(requestingPlayerId);
+
+      if (isRequestingPlayer) {
+
+        List<CardDto> handDtos = new ArrayList<>();
+
+        for (Card card : player.getHand()) {
+
+          CardDto cardDto = new CardDto();
+
+          cardDto.setId(card.getId());
+          cardDto.setName(card.getName());
+          cardDto.setType(card.getType());
+
+          handDtos.add(cardDto);
+        }
+
+        playerDto.setHand(handDtos);
+      }
+
+      playerDtos.add(playerDto);
+    }
+
+    dto.setPlayers(playerDtos);
+
+    return dto;
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/dto/PlayerStateDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/PlayerStateDto.java
@@ -1,0 +1,75 @@
+package com.doomhamsters.gamesession.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * DTO representing a player's visible state.
+ */
+public class PlayerStateDto {
+
+  private String playerId;
+
+  private String playerName;
+
+  private int lives;
+
+  private boolean alive;
+
+  private int handSize;
+
+  private List<CardDto> hand = new ArrayList<>();
+
+  public PlayerStateDto() {
+  }
+
+  public String getPlayerId() {
+    return playerId;
+  }
+
+  public void setPlayerId(String playerId) {
+    this.playerId = playerId;
+  }
+
+  public String getPlayerName() {
+    return playerName;
+  }
+
+  public void setPlayerName(String playerName) {
+    this.playerName = playerName;
+  }
+
+  public int getLives() {
+    return lives;
+  }
+
+  public void setLives(int lives) {
+    this.lives = lives;
+  }
+
+  public boolean isAlive() {
+    return alive;
+  }
+
+  public void setAlive(boolean alive) {
+    this.alive = alive;
+  }
+
+  public int getHandSize() {
+    return handSize;
+  }
+
+  public void setHandSize(int handSize) {
+    this.handSize = handSize;
+  }
+
+  public List<CardDto> getHand() {
+    return new ArrayList<>(hand);
+  }
+
+  public void setHand(List<CardDto> hand) {
+    this.hand = hand == null
+        ? new ArrayList<>()
+        : new ArrayList<>(hand);
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/dto/PlayerStateDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/PlayerStateDto.java
@@ -67,6 +67,11 @@ public class PlayerStateDto {
     return new ArrayList<>(hand);
   }
 
+  /**
+   * Sets the visible hand cards for the player.
+   *
+   * @param hand the visible hand cards
+   */
   public void setHand(List<CardDto> hand) {
     this.hand = hand == null
         ? new ArrayList<>()

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionPersistenceServiceTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionPersistenceServiceTests.java
@@ -1,0 +1,49 @@
+package com.doomhamsters.gamesession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.File;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class GameSessionPersistenceServiceTests {
+
+  private static final String FILE_PATH = "sessions.json";
+
+  @AfterEach
+  void cleanup() {
+    new File(FILE_PATH).delete();
+  }
+
+  @Test
+  void saveAndLoadSessionsShouldWork() {
+
+    GameSessionPersistenceService persistence =
+        new GameSessionPersistenceService();
+
+    ConcurrentHashMap<String, GameSession> sessions =
+        new ConcurrentHashMap<>();
+
+    GameSession session =
+        new GameSession("game-1", "lobby-1");
+
+    sessions.put(session.getGameId(), session);
+
+    persistence.saveSessions(sessions);
+
+    ConcurrentHashMap<String, GameSession> loaded =
+        persistence.loadSessions();
+
+    assertFalse(loaded.isEmpty());
+
+    assertEquals(
+        "game-1",
+        loaded.get("game-1").getGameId());
+
+    assertEquals(
+        "lobby-1",
+        loaded.get("game-1").getLobbyId());
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.util.Optional;
+import java.io.File;
+import org.junit.jupiter.api.AfterEach;
 
 class GameSessionServiceTests {
 
@@ -12,6 +14,11 @@ class GameSessionServiceTests {
   @BeforeEach
   void setUp() {
     service = new GameSessionService(new GameSessionPersistenceService());
+  }
+
+  @AfterEach
+  void cleanup() {
+    new File("sessions.json").delete();
   }
 
   @Test
@@ -44,5 +51,26 @@ class GameSessionServiceTests {
     Optional<GameSession> retrieved = service.getSession("manual-id");
     assertTrue(retrieved.isPresent());
     assertEquals("lobby-x", retrieved.get().getLobbyId());
+  }
+
+  @Test
+  void testSessionsPersistAcrossServiceRestart() {
+
+    GameSession created =
+        service.createSession("persistent-lobby");
+
+    GameSessionService restartedService =
+        new GameSessionService(
+            new GameSessionPersistenceService());
+
+    Optional<GameSession> restored =
+        restartedService.getSession(
+            created.getGameId());
+
+    assertTrue(restored.isPresent());
+
+    assertEquals(
+        "persistent-lobby",
+        restored.get().getLobbyId());
   }
 }

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
@@ -11,7 +11,7 @@ class GameSessionServiceTests {
 
   @BeforeEach
   void setUp() {
-    service = new GameSessionService();
+    service = new GameSessionService(new GameSessionPersistenceService());
   }
 
   @Test

--- a/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
@@ -1,0 +1,61 @@
+package com.doomhamsters.gamesession.dto;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.doomhamsters.gamesession.GameSession;
+import com.doomhamsters.gamesession.GameSessionPersistenceService;
+import com.doomhamsters.gamesession.GameSessionService;
+import com.doomhamsters.gamesession.dto.GameStateMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class GameStateControllerTests {
+
+  private MockMvc mockMvc;
+
+  private GameSessionService gameSessionService;
+
+  @BeforeEach
+  void setUp() {
+
+    gameSessionService =
+        new GameSessionService(
+            new GameSessionPersistenceService());
+
+    GameStateMapper mapper =
+        new GameStateMapper();
+
+    GameStateController controller =
+        new GameStateController(
+            gameSessionService,
+            mapper);
+
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .build();
+  }
+
+  @Test
+  void shouldReturn404WhenGameDoesNotExist() throws Exception {
+
+    mockMvc.perform(
+            get("/api/game/missing/state")
+                .param("playerId", "p1"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void shouldReturn200WhenGameExists() throws Exception {
+
+    GameSession session =
+        gameSessionService.createSession("lobby-1");
+
+    mockMvc.perform(
+            get("/api/game/" + session.getGameId() + "/state")
+                .param("playerId", "p1"))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/dto/GameStateMapperTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/dto/GameStateMapperTests.java
@@ -1,0 +1,71 @@
+package com.doomhamsters.gamesession.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.doomhamsters.Card;
+import com.doomhamsters.Game;
+import com.doomhamsters.Player;
+import com.doomhamsters.gamesession.GameSession;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GameStateMapperTest {
+
+  @Test
+  void shouldHideOtherPlayersHands() throws Exception {
+
+    GameSession session =
+        new GameSession("game-1", "lobby-1");
+
+    Game game = session.getGame();
+
+    Player player1 = new Player("p1", "Alice");
+    Player player2 = new Player("p2", "Bob");
+
+    player1.addToHand(
+        new Card("c1", "Attack", "action"));
+
+    player2.addToHand(
+        new Card("c2", "Defend", "action"));
+
+    Field playersField =
+        Game.class.getDeclaredField("players");
+
+    playersField.setAccessible(true);
+
+    List<Player> players = new ArrayList<>();
+    players.add(player1);
+    players.add(player2);
+
+    playersField.set(game, players);
+
+    GameStateMapper mapper =
+        new GameStateMapper();
+
+    GameStateDto dto =
+        mapper.toFilteredDto(session, "p1");
+
+    assertEquals(2, dto.getPlayers().size());
+
+    var ownPlayer =
+        dto.getPlayers().stream()
+            .filter(p -> p.getPlayerId().equals("p1"))
+            .findFirst()
+            .orElseThrow();
+
+    var enemyPlayer =
+        dto.getPlayers().stream()
+            .filter(p -> p.getPlayerId().equals("p2"))
+            .findFirst()
+            .orElseThrow();
+
+    assertEquals(1, ownPlayer.getHand().size());
+
+    assertTrue(enemyPlayer.getHand().isEmpty());
+
+    assertEquals(1, enemyPlayer.getHandSize());
+  }
+}


### PR DESCRIPTION
## Summary

Implements game state recovery and reconnect support for active game sessions.

## Changes

* Added DTO classes for filtered game state responses:

  * `GameStateDto`
  * `PlayerStateDto`
  * `CardDto`

* Added reconnect endpoint and state mapping:

  * `GameStateController`
  * `GameStateMapper`

* Added deep copy constructors for:

  * `Game`
  * `Board`
  * `Deck`
  * `Player`
  * `Card`

* Added defensive copying to avoid exposing mutable internal state

* Added missing Javadocs for DTO setters and copy constructors

* Fixed SpotBugs encapsulation warnings (`EI_EXPOSE_REP`, `EI_EXPOSE_REP2`)

* Fixed PMD/Javadoc related issues

* Added tests for:

  * persistence service
  * reconnect endpoint
  * DTO mapping
  * game state recovery flow

## Verification

* `mvn verify` passes
* SpotBugs warnings resolved
* PMD checks pass
* Tests added and passing
