### PR TITLE
Persistence / container restart - further adjustments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     restart: unless-stopped
     ports:
       - "53217:8080"
+    volumes:
+      - sessions_data:/data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     restart: unless-stopped
     ports:
       - "53217:8080"
+    environment:
+      - SESSIONS_FILE_PATH=/data/session.json
     volumes:
       - sessions_data:/data
     healthcheck:

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
@@ -32,8 +32,9 @@ public class GameSessionPersistenceService {
     try {
       File file = new File(filePath);
       File parent = file.getParentFile();
-      if (parent != null) {
-        parent.mkdirs();
+      if (parent != null && !parent.exists() && !parent.mkdirs()) {
+        System.err.println("Failed to create directory: " + parent.getAbsolutePath());
+        return;
       }
       objectMapper.writerWithDefaultPrettyPrinter().writeValue(file, sessions);
     } catch (Exception e) {

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
@@ -29,10 +29,16 @@ public class GameSessionPersistenceService {
    * @param sessions all active sessions
    */
   public void saveSessions(ConcurrentHashMap<String, GameSession> sessions) {
-
-    objectMapper.writerWithDefaultPrettyPrinter()
-        .writeValue(new File(filePath), sessions);
-
+    try {
+      File file = new File(filePath);
+      File parent = file.getParentFile();
+      if (parent != null) {
+        parent.mkdirs();
+      }
+      objectMapper.writerWithDefaultPrettyPrinter().writeValue(file, sessions);
+    } catch (Exception e) {
+      System.err.println("Failed to save sessions: " + e.getMessage());
+    }
   }
 
   /**
@@ -48,9 +54,13 @@ public class GameSessionPersistenceService {
       return new ConcurrentHashMap<>();
     }
 
-    return objectMapper.readValue(
-        file,
-        new TypeReference<ConcurrentHashMap<String, GameSession>>() {});
-
+    try {
+      return objectMapper.readValue(
+          file,
+          new TypeReference<ConcurrentHashMap<String, GameSession>>() {});
+    } catch (Exception e) {
+      System.err.println("Failed to load sessions, starting fresh: " + e.getMessage());
+      return new ConcurrentHashMap<>();
+    }
   }
 }

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
@@ -2,6 +2,7 @@ package com.doomhamsters.gamesession;
 
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
@@ -12,11 +13,13 @@ import tools.jackson.databind.ObjectMapper;
 @Service
 public class GameSessionPersistenceService {
 
-  private static final String FILE_PATH = "/data/sessions.json";
-
+  private final String filePath;
   private final ObjectMapper objectMapper;
 
-  public GameSessionPersistenceService() {
+  public GameSessionPersistenceService(
+      @Value("${sessions.file.path:sessions.json}") String filePath
+  ) {
+    this.filePath = filePath;
     this.objectMapper = new ObjectMapper();
   }
 
@@ -28,7 +31,7 @@ public class GameSessionPersistenceService {
   public void saveSessions(ConcurrentHashMap<String, GameSession> sessions) {
 
     objectMapper.writerWithDefaultPrettyPrinter()
-        .writeValue(new File(FILE_PATH), sessions);
+        .writeValue(new File(filePath), sessions);
 
   }
 
@@ -39,7 +42,7 @@ public class GameSessionPersistenceService {
    */
   public ConcurrentHashMap<String, GameSession> loadSessions() {
 
-    File file = new File(FILE_PATH);
+    File file = new File(filePath);
 
     if (!file.exists()) {
       return new ConcurrentHashMap<>();

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
@@ -12,7 +12,7 @@ import tools.jackson.databind.ObjectMapper;
 @Service
 public class GameSessionPersistenceService {
 
-  private static final String FILE_PATH = "sessions.json";
+  private static final String FILE_PATH = "/data/sessions.json";
 
   private final ObjectMapper objectMapper;
 

--- a/src/main/java/com/doomhamsters/gamesession/dto/GameStateController.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/GameStateController.java
@@ -51,6 +51,9 @@ public class GameStateController {
 
     return gameSessionService
         .getSession(gameId)
+        .filter(session -> session.getGame() != null
+            && session.getGame().getPlayers().stream()
+                .anyMatch(p -> p.getId().equals(playerId)))
         .map(session -> {
 
           GameStateDto dto =

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionPersistenceServiceTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionPersistenceServiceTests.java
@@ -5,23 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class GameSessionPersistenceServiceTests {
 
-  private static final String FILE_PATH = "sessions.json";
-
-  @AfterEach
-  void cleanup() {
-    new File(FILE_PATH).delete();
-  }
+  @TempDir
+  File tempDir;
 
   @Test
   void saveAndLoadSessionsShouldWork() {
-
+    String filePath = new File(tempDir, "sessions.json").getAbsolutePath();
     GameSessionPersistenceService persistence =
-        new GameSessionPersistenceService();
+        new GameSessionPersistenceService(filePath);
 
     ConcurrentHashMap<String, GameSession> sessions =
         new ConcurrentHashMap<>();

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
@@ -1,24 +1,24 @@
 package com.doomhamsters.gamesession;
 
 import static org.junit.jupiter.api.Assertions.*;
+import java.io.File;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import java.util.Optional;
-import java.io.File;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.io.TempDir;
 
 class GameSessionServiceTests {
 
+  @TempDir
+  File tempDir;
+
+  private String filePath;
   private GameSessionService service;
 
   @BeforeEach
   void setUp() {
-    service = new GameSessionService(new GameSessionPersistenceService());
-  }
-
-  @AfterEach
-  void cleanup() {
-    new File("sessions.json").delete();
+    filePath = new File(tempDir, "sessions.json").getAbsolutePath();
+    service = new GameSessionService(new GameSessionPersistenceService(filePath));
   }
 
   @Test
@@ -61,7 +61,7 @@ class GameSessionServiceTests {
 
     GameSessionService restartedService =
         new GameSessionService(
-            new GameSessionPersistenceService());
+            new GameSessionPersistenceService(filePath));
 
     Optional<GameSession> restored =
         restartedService.getSession(

--- a/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
@@ -3,11 +3,14 @@ package com.doomhamsters.gamesession.dto;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.doomhamsters.Card;
 import com.doomhamsters.gamesession.GameSession;
 import com.doomhamsters.gamesession.GameSessionPersistenceService;
 import com.doomhamsters.gamesession.GameSessionService;
 import com.doomhamsters.gamesession.dto.GameStateMapper;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,19 +51,54 @@ class GameStateControllerTests {
 
     mockMvc.perform(
             get("/api/game/missing/state")
-                .param("playerId", "p1"))
+                .param("playerId", "p0"))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void shouldReturn200WhenGameExists() throws Exception {
+  void shouldReturn404WhenGameNotSetUp() throws Exception {
 
     GameSession session =
         gameSessionService.createSession("lobby-1");
 
     mockMvc.perform(
             get("/api/game/" + session.getGameId() + "/state")
-                .param("playerId", "p1"))
+                .param("playerId", "p0"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void shouldReturn404WhenPlayerNotInGame() throws Exception {
+
+    GameSession session = gameSessionService.createSession("lobby-1");
+    setupGame(session);
+
+    mockMvc.perform(
+            get("/api/game/" + session.getGameId() + "/state")
+                .param("playerId", "unknown"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void shouldReturn200WhenPlayerIsInGame() throws Exception {
+
+    GameSession session = gameSessionService.createSession("lobby-1");
+    setupGame(session);
+
+    mockMvc.perform(
+            get("/api/game/" + session.getGameId() + "/state")
+                .param("playerId", "p0"))
         .andExpect(status().isOk());
+  }
+
+  private void setupGame(GameSession session) {
+    Card snackStash = new Card("ss", "Snack Stash", "snack_stash", null);
+    Card doom = new Card("doom-1", "Doom", "doom", null);
+    List<Card> actionCards = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      actionCards.add(new Card("action-" + i, "Action " + i, "action", null));
+    }
+    session.getGame().setup(List.of("Alice", "Bob"), actionCards, snackStash, List.of(doom));
+    gameSessionService.saveSession(session);
   }
 }

--- a/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
@@ -7,12 +7,17 @@ import com.doomhamsters.gamesession.GameSession;
 import com.doomhamsters.gamesession.GameSessionPersistenceService;
 import com.doomhamsters.gamesession.GameSessionService;
 import com.doomhamsters.gamesession.dto.GameStateMapper;
+import java.io.File;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class GameStateControllerTests {
+
+  @TempDir
+  File tempDir;
 
   private MockMvc mockMvc;
 
@@ -20,10 +25,10 @@ class GameStateControllerTests {
 
   @BeforeEach
   void setUp() {
-
+    String filePath = new File(tempDir, "sessions.json").getAbsolutePath();
     gameSessionService =
         new GameSessionService(
-            new GameSessionPersistenceService());
+            new GameSessionPersistenceService(filePath));
 
     GameStateMapper mapper =
         new GameStateMapper();


### PR DESCRIPTION
- place session.json file under into /data folder, mounted to /sessions_data folder on the host machine (iniversity server).
- refactored to validate that playerId belongs to game in state endpoint.