### PR TITLE
Add API documentation — Swagger UI, AsyncAPI, Javadoc, README

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,7 @@
 name: Build and Push Docker Image
+
+# Triggered on every push to main — builds the Docker image and publishes it
+# to GitHub Container Registry (ghcr.io) so doco-cd can deploy it automatically.
 on:
   push:
     branches:
@@ -8,14 +11,17 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: read   # needed to checkout the repository
+      packages: write  # needed to push to ghcr.io
 
     steps:
       - name: Checkout code
+        # Pinned to full SHA for supply-chain security (tag v4)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Log in to GitHub Container Registry
+        # github.actor + GITHUB_TOKEN authenticate as the user who triggered the push.
+        # GITHUB_TOKEN is automatically provided by GitHub Actions — no manual secret needed.
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3
         with:
           registry: ghcr.io
@@ -23,9 +29,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
+        # Builds the Dockerfile and overwrites the :latest tag on ghcr.io.
+        # doco-cd detects the new :latest image within ~3 minutes and redeploys.
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 #v5
         with:
           context: .
           push: true
           tags: ghcr.io/se2-doomhamsters/server:latest
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-# Build the jar using Maven
+# ── Stage 1: Build ────────────────────────────────────────────────────────────
+# Uses a full Maven + JDK image to compile the project and produce a fat JAR.
+# Dependencies are downloaded first (separate layer) so rebuilds are faster
+# when only source code changes.
 FROM maven:3.9-eclipse-temurin-21 AS builder
 WORKDIR /app
 COPY pom.xml .
@@ -6,9 +9,15 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn package -DskipTests -B
 
-# Run the jar using a lightweight JRE
+# ── Stage 2: Run ──────────────────────────────────────────────────────────────
+# Uses a lightweight JRE-only image — no Maven, no compiler, no source code.
+# Only the compiled JAR from Stage 1 is copied over, keeping the final image small.
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
+
+# Document that the server listens on port 8080 inside the container.
+# Mapped to the university server port 53217 via docker-compose.yml.
 EXPOSE 8080
+
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# backend
+# Backend
 This project is a Java-based backend server for a multiplayer card game.  
 It uses WebSockets for real-time communication between clients and the server.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ It uses WebSockets for real-time communication between clients and the server.
 The system manages game state, player actions, and turn-based logic on the server side.
 
 
+## API Documentation
+
+| What | Where |
+|------|-------|
+| REST API (Swagger UI) — local | `http://localhost:8080/swagger-ui.html` |
+| REST API (Swagger UI) — university server | `http://se2-demo.aau.at:53217/swagger-ui.html` |
+| WebSocket/STOMP channels (AsyncAPI) | [`asyncapi.yml`](asyncapi.yml) in the project root |
+| Java source documentation (Javadoc) | Generate with `./mvnw javadoc:javadoc`, then open `target/reports/apidocs/index.html` |
+
+**Swagger UI** — start the server (`./mvnw spring-boot:run`) and open the URL above in a browser. No extra steps needed.
+
+**AsyncAPI** — open [`asyncapi.yml`](asyncapi.yml) directly, or paste it into [studio.asyncapi.com](https://studio.asyncapi.com) for a rendered view.
+
+**Javadoc** — run `./mvnw javadoc:javadoc` and open `target/reports/apidocs/index.html` in a browser.
+
 ##Features
 
 - Real-time multiplayer communication via WebSockets

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The system manages game state, player actions, and turn-based logic on the serve
 
 **Javadoc** — run `./mvnw javadoc:javadoc` and open `target/reports/apidocs/index.html` in a browser.
 
-##Features
+## Features
 
 - Real-time multiplayer communication via WebSockets
 - Server-authoritative game state management
@@ -34,10 +34,9 @@ The backend follows a modular structure
 - Game logic is server-side to prevent cheating and ensure consistency.
 - Card effects are implemented using functional interfaces for flexibility.
 
-- ## Example Usage
+## Example Usage
 
 1. Start the server
 2. Connect via WebSocket (e.g., using Postman or a frontend client)
 3. Send a QR code to the host
 4. Play actions using the client
-5. 

--- a/asyncapi.yml
+++ b/asyncapi.yml
@@ -1,0 +1,249 @@
+asyncapi: 3.1.0
+info:
+  title: DoomHamsters WebSocket API
+  version: 1.0.0
+  description: >
+    Real-time STOMP over WebSocket API for the DoomHamsters card game.
+
+
+    ## Connection
+
+    Connect to the STOMP handshake endpoint:
+
+    - Production:  ws://<university-server-ip>:53217/ws
+
+    - Development: ws://localhost:8080/ws
+
+
+    The Android client uses the Krossbow library with OkHttp WebSocket
+    transport.
+
+
+    ## Channel prefixes
+
+    - /topic/...  — broadcast to all subscribers (public game state)
+
+    - /queue/...  — directed to a single client (private information)
+
+    - /app/...    — client sends messages to server @MessageMapping handlers
+servers:
+  production:
+    host: '{host}:53217'
+    protocol: ws
+    description: University server — deployed via doco-cd on every push to main
+    variables:
+      host:
+        description: University server IP address (provided by LV-Leiter)
+  development:
+    host: 'localhost:8080'
+    protocol: ws
+    description: Local development server
+channels:
+  '/topic/lobby/{lobbyId}':
+    address: '/topic/lobby/{lobbyId}'
+    messages:
+      onLobbyUpdate.message:
+        $ref: '#/components/messages/LobbyMessage'
+    description: >
+      Broadcast updated lobby state to all subscribers whenever a player joins.
+      Triggered by POST /api/lobby/{lobbyId}/join. Subscribe immediately after
+      creating or joining a lobby.
+    parameters:
+      lobbyId:
+        description: The lobby identifier returned by POST /api/lobby/create
+  '/topic/game/{lobbyId}':
+    address: '/topic/game/{lobbyId}'
+    messages:
+      onGameStart.message:
+        $ref: '#/components/messages/GameStartMessage'
+    description: >
+      Broadcast game start notification to all lobby subscribers. Triggered by
+      POST /api/game/start. Subscribe before the host starts the game to receive
+      the gameId.
+    parameters:
+      lobbyId:
+        description: The lobby identifier used to start the game
+  '/topic/game/{gameId}':
+    address: '/topic/game/{gameId}'
+    messages:
+      onGameStateUpdate.message:
+        $ref: '#/components/messages/GameStateMessage'
+    description: >
+      [PLANNED] Broadcast updated game state to all players after every turn.
+      Subscribe after receiving the gameId from /topic/game/{lobbyId}. Other
+      players' hands are always hidden — only hand size is visible.
+    parameters:
+      gameId:
+        description: The game session identifier received from GameStartResponse
+  '/queue/game/{gameId}/private/{playerId}':
+    address: '/queue/game/{gameId}/private/{playerId}'
+    messages:
+      onPrivateCardInfo.message:
+        $ref: '#/components/messages/PrivateCardMessage'
+    description: >
+      [PLANNED] Private card information sent only to the requesting player.
+      Used by Sniff Ahead (top 3 cards) and Quick Peek (top 1 card). Other
+      players receive no notification about the content.
+    parameters:
+      gameId:
+        description: The game session identifier
+      playerId:
+        description: The player identifier (only this player receives the message)
+operations:
+  onLobbyUpdate:
+    action: send
+    channel:
+      $ref: '#/channels/~1topic~1lobby~1{lobbyId}'
+    summary: Receive updated lobby state when a new player joins
+    messages:
+      - $ref: '#/channels/~1topic~1lobby~1{lobbyId}/messages/onLobbyUpdate.message'
+  onGameStart:
+    action: send
+    channel:
+      $ref: '#/channels/~1topic~1game~1{lobbyId}'
+    summary: Receive game start notification containing the new gameId
+    messages:
+      - $ref: '#/channels/~1topic~1game~1{lobbyId}/messages/onGameStart.message'
+  onGameStateUpdate:
+    action: send
+    channel:
+      $ref: '#/channels/~1topic~1game~1{gameId}'
+    summary: Receive game state after each turn
+    messages:
+      - $ref: '#/channels/~1topic~1game~1{gameId}/messages/onGameStateUpdate.message'
+  onPrivateCardInfo:
+    action: send
+    channel:
+      $ref: '#/channels/~1queue~1game~1{gameId}~1private~1{playerId}'
+    summary: Receive private card information visible only to you
+    messages:
+      - $ref: >-
+          #/channels/~1queue~1game~1{gameId}~1private~1{playerId}/messages/onPrivateCardInfo.message
+components:
+  messages:
+    LobbyMessage:
+      name: Lobby
+      summary: Current lobby state including all members and QR code
+      payload:
+        type: object
+        properties:
+          lobbyId:
+            type: string
+            example: abc-123
+          groupName:
+            type: string
+            example: DoomHamsters
+          members:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+          qrCodeBase64:
+            type: string
+            description: Base64-encoded PNG QR code for joining the lobby via scan
+    GameStartMessage:
+      name: GameStartResponse
+      summary: Signals that the game has started; contains the gameId to subscribe to
+      payload:
+        type: object
+        properties:
+          gameId:
+            type: string
+            description: >-
+              Use this to subscribe to /topic/game/{gameId} for game state
+              updates
+            example: 550e8400-e29b-41d4-a716-446655440000
+    GameStateMessage:
+      name: GameStateDto
+      summary: >-
+        Filtered game state — own hand is fully visible, other players show hand
+        size only
+      payload:
+        type: object
+        properties:
+          gameId:
+            type: string
+          gameState:
+            type: string
+            enum:
+              - SETUP
+              - RUNNING
+              - FINISHED
+          currentPlayerId:
+            type: string
+            description: ID of the player whose turn it currently is
+          turnCount:
+            type: integer
+            description: Total number of turns played so far
+          players:
+            type: array
+            items:
+              $ref: '#/components/schemas/PlayerState'
+    PrivateCardMessage:
+      name: PrivateCardInfo
+      summary: >-
+        Cards visible only to the requesting player (Sniff Ahead / Quick Peek
+        result)
+      payload:
+        type: object
+        properties:
+          cards:
+            type: array
+            description: Top card(s) from the deck in draw order
+            items:
+              $ref: '#/components/schemas/Card'
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique player identifier
+        username:
+          type: string
+          example: Olha
+        avatar:
+          type: string
+          example: dog
+    PlayerState:
+      type: object
+      properties:
+        playerId:
+          type: string
+        playerName:
+          type: string
+        lives:
+          type: integer
+          minimum: 0
+          description: Remaining lives (starts at 3)
+        alive:
+          type: boolean
+        handSize:
+          type: integer
+          description: Number of cards in hand — visible to all players
+        hand:
+          type: array
+          description: >-
+            Actual cards — only populated for the requesting player, empty for
+            others
+          items:
+            $ref: '#/components/schemas/Card'
+    Card:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique card instance identifier
+        name:
+          type: string
+          example: Power Nap
+        type:
+          type: string
+          enum:
+            - action
+            - snack_stash
+            - doom
+            - hamster_fat
+            - hamster_ninja
+            - hamster_sleepy
+            - hamster_gremlin
+            - hamster_zombi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,31 @@
 services:
   server:
+    # Pre-built image from GitHub Container Registry — built on every push to main via GitHub Actions
     image: ghcr.io/se2-doomhamsters/server:latest
-    restart: unless-stopped
-    ports:
-      - "53217:8080"
-    environment:
-      - SESSIONS_FILE_PATH=/data/session.json
-    volumes:
-      - sessions_data:/data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
 
+    # Restart automatically on crash; skip restart only if manually stopped
+    restart: unless-stopped
+
+    ports:
+      # <university-server-port>:<container-internal-port>
+      - "53217:8080"
+
+    environment:
+      # Override default sessions.json path to write inside the Docker volume
+      - SESSIONS_FILE_PATH=/data/sessions.json
+
+    volumes:
+      # Persists game sessions across container restarts and redeployments
+      # Lives on the host at /var/lib/docker/volumes/server_sessions_data/
+      - sessions_data:/data
+
+    healthcheck:
+      # Docker checks this endpoint every 30s to determine container health
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 30s   # how often to check
+      timeout: 5s     # max time to wait for a response
+      retries: 3      # consecutive failures before marking unhealthy
+
+volumes:
+  # Named volume — managed by Docker, survives container recreation by doco-cd
+  sessions_data:

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
             <version>4.0.3</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/doomhamsters/config/OpenApiConfig.java
+++ b/src/main/java/com/doomhamsters/config/OpenApiConfig.java
@@ -1,0 +1,48 @@
+package com.doomhamsters.config;
+
+import  io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the OpenAPI (Swagger) documentation metadata.
+ *
+ * <p>The generated UI is available at /swagger-ui.html when the server is running.
+ */
+@Configuration
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class OpenApiConfig {
+
+  /**
+   * Defines the OpenAPI metadata shown in Swagger UI.
+   *
+   * @return configured OpenAPI instance
+   */
+  @Bean
+  public OpenAPI customOpenApi() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("DoomHamsters Game API")
+            .description("REST and WebSocket API for the DoomHamsters card game server. "
+                + "For WebSocket/STOMP channel documentation see asyncapi.yml.")
+            .version("1.0.0")
+            .contact(new Contact()
+                .name("Gruppe Beta — Doom Hamsters")
+                .url("https://github.com/SE2-DoomHamsters/server")))
+        .servers(List.of(
+            new Server()
+                .url("http://localhost:8080")
+                .description("Local development"),
+            new Server()
+                .url("http://se2-demo.aau.at:53217")
+                .description("University server (doco-cd deployment)")))
+        .externalDocs(new ExternalDocumentation()
+            .description("WebSocket API documentation (AsyncAPI)")
+            .url("https://github.com/SE2-DoomHamsters/server/blob/main/asyncapi.yml"));
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceService.java
@@ -8,7 +8,16 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * Handles persistence of game sessions to disk.
+ * Handles persistence of game sessions to disk as JSON.
+ *
+ * <p>The file path is configurable via the {@code sessions.file.path} property
+ * (default: {@code sessions.json} in the working directory).
+ * In Docker, this is overridden by the {@code SESSIONS_FILE_PATH} environment variable
+ * to {@code /data/sessions.json}, which is mounted to a named Docker volume so that
+ * sessions survive container restarts and redeployments.
+ *
+ * <p>If saving or loading fails, the error is logged and the server continues running —
+ * sessions are always available in memory even if disk persistence is unavailable.
  */
 @Service
 public class GameSessionPersistenceService {

--- a/src/main/java/com/doomhamsters/gamesession/GameStartResponse.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameStartResponse.java
@@ -1,9 +1,16 @@
 package com.doomhamsters.gamesession;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
- * simple DTO to signal that a game has started and provide its ID.
+ * Simple DTO to signal that a game has started and provide its ID.
  */
+@Schema(description = "Response returned when a game is successfully started")
 public class GameStartResponse {
+
+  @Schema(description = "Unique game session identifier — use this to subscribe to "
+      + "/topic/game/{gameId} for real-time game state updates",
+      example = "550e8400-e29b-41d4-a716-446655440000")
   private final String gameId;
 
   public GameStartResponse(String gameId) {

--- a/src/main/java/com/doomhamsters/gamesession/dto/GameStateController.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/GameStateController.java
@@ -1,6 +1,12 @@
 package com.doomhamsters.gamesession.dto;
 
 import com.doomhamsters.gamesession.GameSessionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * REST endpoints for game state recovery and reconnects.
  */
+@Tag(name = "Game State",
+    description = "Game state recovery for reconnecting players — "
+        + "returns filtered state with own hand visible and other players' hands hidden")
 @RestController
 @RequestMapping("/api/game")
 public class GameStateController {
@@ -44,10 +53,19 @@ public class GameStateController {
    * @param playerId the reconnecting player
    * @return filtered game state
    */
+  @Operation(
+      summary = "Get filtered game state for a reconnecting player",
+      description = "Returns the current game state with the requesting player's full hand visible."
+          + "All other players' hands are hidden — only hand size is shown. "
+          + "Returns 404 if the game does not exist or the playerId is not part of this game.")
+  @ApiResponse(responseCode = "200", description = "Game state returned successfully",
+      content = @Content(schema = @Schema(implementation = GameStateDto.class)))
+  @ApiResponse(responseCode = "404",
+      description = "Game not found or player is not a member of this game")
   @GetMapping("/{gameId}/state")
   public ResponseEntity<GameStateDto> getGameState(
-      @PathVariable String gameId,
-      @RequestParam String playerId) {
+      @Parameter(description = "Game session identifier") @PathVariable String gameId,
+      @Parameter(description = "ID of the reconnecting player") @RequestParam String playerId) {
 
     return gameSessionService
         .getSession(gameId)

--- a/src/main/java/com/doomhamsters/lobby/CreateLobbyRequest.java
+++ b/src/main/java/com/doomhamsters/lobby/CreateLobbyRequest.java
@@ -1,9 +1,15 @@
 package com.doomhamsters.lobby;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /** DTO for the create-lobby REST request. */
+@Schema(description = "Request body for creating a new lobby")
 public class CreateLobbyRequest {
 
+  @Schema(description = "Display name of the group/lobby", example = "DoomHamsters")
   private String groupName;
+
+  @Schema(description = "The player creating the lobby")
   private User user;
 
   public CreateLobbyRequest() {}

--- a/src/main/java/com/doomhamsters/lobby/LobbyController.java
+++ b/src/main/java/com/doomhamsters/lobby/LobbyController.java
@@ -1,5 +1,11 @@
 package com.doomhamsters.lobby;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>Create/join use HTTP request-response. After a join the updated lobby is
  * also broadcast via STOMP so all connected clients see the new member.
  */
+@Tag(name = "Lobby", description = "Lobby lifecycle — create, join and fetch lobby state")
 @RestController
 @RequestMapping("/api/lobby")
 public class LobbyController {
@@ -36,6 +43,10 @@ public class LobbyController {
    * @param request body containing {@code groupName} and the creator {@code user}
    * @return the created lobby with generated QR code
    */
+  @Operation(summary = "Create a new lobby",
+      description = "Creates a lobby with a QR code. The creator is added as the first member.")
+  @ApiResponse(responseCode = "200", description = "Lobby created successfully",
+      content = @Content(schema = @Schema(implementation = Lobby.class)))
   @PostMapping("/create")
   public ResponseEntity<Lobby> createLobby(@RequestBody CreateLobbyRequest request) {
     Lobby lobby = lobbyService.createLobby(request.getGroupName(), request.getUser());
@@ -51,9 +62,16 @@ public class LobbyController {
    * @param user the joining player
    * @return updated lobby, or 404 if the lobby does not exist
    */
+  @Operation(summary = "Join an existing lobby",
+      description = "Adds the player to the lobby and broadcasts the updated lobby"
+          + " to all STOMP subscribers on /topic/lobby/{lobbyId}.")
+  @ApiResponse(responseCode = "200", description = "Lobby joined successfully",
+      content = @Content(schema = @Schema(implementation = Lobby.class)))
+  @ApiResponse(responseCode = "404", description = "Lobby not found")
   @PostMapping("/{lobbyId}/join")
   public ResponseEntity<Lobby> joinLobby(
-      @PathVariable String lobbyId, @RequestBody User user) {
+      @Parameter(description = "Lobby identifier") @PathVariable String lobbyId,
+      @RequestBody User user) {
     return lobbyService
         .joinOrUpdateLobby(lobbyId, user)
         .map(
@@ -73,8 +91,13 @@ public class LobbyController {
    * @param lobbyId the target lobby identifier
    * @return lobby state, or 404 if not found
    */
+  @Operation(summary = "Get current lobby state")
+  @ApiResponse(responseCode = "200", description = "Lobby found",
+      content = @Content(schema = @Schema(implementation = Lobby.class)))
+  @ApiResponse(responseCode = "404", description = "Lobby not found")
   @GetMapping("/{lobbyId}")
-  public ResponseEntity<Lobby> getLobby(@PathVariable String lobbyId) {
+  public ResponseEntity<Lobby> getLobby(
+      @Parameter(description = "Lobby identifier") @PathVariable String lobbyId) {
     Lobby lobby = lobbyService.getLobby(lobbyId);
     return lobby != null ? ResponseEntity.ok(lobby) : ResponseEntity.notFound().build();
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.application.name=DoomHamsters
 server.port=8080
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+springdoc.show-actuator=true
+springdoc.use-management-port=false


### PR DESCRIPTION
 Body:
  ## Summary
  - Adds springdoc-openapi with full Swagger UI at /swagger-ui.html — annotated REST endpoints and DTOs
  - Adds asyncapi.yml (AsyncAPI 3.1.0) documenting WebSocket/STOMP channels
  - Updates README with links and instructions for accessing all three documentation types
  
  ## Test plan
  - [ ] Start server locally, open http://localhost:8080/swagger-ui.html — all endpoints visible
  - [ ] Paste asyncapi.yml into studio.asyncapi.com — renders without errors
  - [ ] Run ./mvnw javadoc:javadoc — opens at target/reports/apidocs/index.html