### PR TITLE
feat(board): add support for stacked extra turns

### DIFF
--- a/src/main/java/com/doomhamsters/Board.java
+++ b/src/main/java/com/doomhamsters/Board.java
@@ -12,8 +12,7 @@ public class Board {
   private final List<Player> players;
   private final Deck deck;
   private final List<Card> discardPile;
-  private int currentIndex;
-  private int turnCount;
+  private int currentIndex, turnCount, extraTurns;
 
   /**
    * Creates a board for the supplied players and deck.
@@ -26,6 +25,7 @@ public class Board {
     this.deck = new Deck(new ArrayList<>(deck.getCards()));
     this.currentIndex = 0;
     this.turnCount = 0;
+    this.extraTurns = 0;
     this.discardPile = new ArrayList<>();
   }
 
@@ -41,6 +41,7 @@ public class Board {
     this.deck = new Deck(deck);
     this.currentIndex = other.currentIndex;
     this.turnCount = other.turnCount;
+    this.extraTurns = other.extraTurns;
 
     this.discardPile = new ArrayList<>();
     for (Card card : other.discardPile) {
@@ -99,12 +100,21 @@ public class Board {
   public List<Card> getDiscardPile() {
     return Collections.unmodifiableList(discardPile);
   }
-  /**
-   * Advances turn.
-   */
 
+  /**
+   * Advances the game turn to the next active player.
+   *
+   * <p>If extra turns are available, one extra turn is consumed and the
+   * current player keeps their turn instead of advancing to the next player.
+   */
   public void advanceTurn() {
+    if (extraTurns > 0) {
+      extraTurns--;
+      return;
+    }
+
     turnCount++;
+
     do {
       currentIndex = (currentIndex + 1) % players.size();
     } while (!players.get(currentIndex).isAlive());
@@ -126,5 +136,24 @@ public class Board {
    */
   public void setCurrentIndex(int index) {
     this.currentIndex = index;
+  }
+
+  /**
+   * Grants the current player an additional turn.
+   *
+   * <p>Extra turns are stacked and consumed one at a time when
+   * {@link #advanceTurn()} is called.
+   */
+  public void addExtraTurn() {
+    extraTurns++;
+  }
+
+  /**
+   * Returns the number of queued extra turns.
+   *
+   * @return queued extra turn count
+   */
+  public int getExtraTurns() {
+    return extraTurns;
   }
 }

--- a/src/test/java/com/doomhamsters/BoardTest.java
+++ b/src/test/java/com/doomhamsters/BoardTest.java
@@ -100,4 +100,41 @@ class BoardTest {
     Deck copiedDeck = board.getDeck();
     assertEquals(30, copiedDeck.getCards().size());
   }
+
+  @Test
+  @DisplayName("advanceTurn() consumes single extra turn")
+  void advanceTurnConsumesSingleExtraTurn() {
+    board.setCurrentIndex(0);
+
+    board.addExtraTurn();
+
+    board.advanceTurn();
+
+    assertEquals("Alice", board.getCurrentPlayer().getName());
+    assertEquals(0, board.getExtraTurns());
+
+    board.advanceTurn();
+
+    assertEquals("Bob", board.getCurrentPlayer().getName());
+  }
+
+  @Test
+  @DisplayName("advanceTurn() consumes stacked extra turns")
+  void advanceTurnConsumesStackedExtraTurns() {
+    board.setCurrentIndex(0);
+
+    board.addExtraTurn();
+    board.addExtraTurn();
+
+    board.advanceTurn();
+    assertEquals("Alice", board.getCurrentPlayer().getName());
+    assertEquals(1, board.getExtraTurns());
+
+    board.advanceTurn();
+    assertEquals("Alice", board.getCurrentPlayer().getName());
+    assertEquals(0, board.getExtraTurns());
+
+    board.advanceTurn();
+    assertEquals("Bob", board.getCurrentPlayer().getName());
+  }
 }


### PR DESCRIPTION
- add extraTurns counter to Board
- add Board.addExtraTurn()
- update advanceTurn() to consume extra turns before advancing
- copy extraTurns in copy constructor
- add getter for extraTurns
- add tests for single and stacked extra turns