### PR TITLE
Extra turn support #54

### DIFF
--- a/src/main/java/com/doomhamsters/Board.java
+++ b/src/main/java/com/doomhamsters/Board.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 /**
  * Represents the game board and manages its state.
  */
@@ -13,8 +14,8 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Board {
 
-  private final List<Player> players;
-  private final Deck deck;
+  private List<Player> players;
+  private Deck deck;
   private final List<Card> discardPile;
   private int currentIndex;
   private int turnCount;
@@ -25,7 +26,7 @@ public class Board {
    * Creates a board for the supplied players and deck.
    *
    * @param players players participating in the game
-   * @param deck draw deck used by the board
+   * @param deck    draw deck used by the board
    */
   public Board(List<Player> players, Deck deck) {
     this.players = new ArrayList<>(players);
@@ -40,9 +41,9 @@ public class Board {
   /**
    * Creates a deep copy of another board.
    *
-   * @param other the board to copy
+   * @param other   the board to copy
    * @param players the copied players to use
-   * @param deck the copied deck to use
+   * @param deck    the copied deck to use
    */
   public Board(Board other, List<Player> players, Deck deck) {
     this.players = new ArrayList<>(players);
@@ -59,13 +60,13 @@ public class Board {
   }
 
   /**
-   * Recreates a board from persisted JSON and defers binding the player order until the
-   * surrounding game has restored its authoritative player list.
+   * Recreates a board from persisted JSON and defers binding the player order until the surrounding
+   * game has restored its authoritative player list.
    *
    * @param currentPlayer player whose turn was active when the game was saved
-   * @param deck restored deck snapshot
-   * @param discardPile restored board discard pile
-   * @param turnCount restored turn count
+   * @param deck          restored deck snapshot
+   * @param discardPile   restored board discard pile
+   * @param turnCount     restored turn count
    */
   @JsonCreator
   public Board(
@@ -101,8 +102,8 @@ public class Board {
 
   public List<Player> getActivePlayers() {
     return players.stream()
-      .filter(Player::isAlive)
-      .toList();
+        .filter(Player::isAlive)
+        .toList();
   }
 
 
@@ -173,7 +174,7 @@ public class Board {
     this.currentIndex = index;
   }
 
-   /**
+  /**
    * Grants the current player an additional turn.
    *
    * <p>Extra turns are stacked and consumed one at a time when
@@ -196,7 +197,7 @@ public class Board {
    * Rebinds restored board state to the authoritative game-level players and deck.
    *
    * @param players authoritative game players
-   * @param deck authoritative game deck
+   * @param deck    authoritative game deck
    */
   void rebindToGameState(List<Player> players, Deck deck) {
     this.players = new ArrayList<>(players);

--- a/src/main/java/com/doomhamsters/Board.java
+++ b/src/main/java/com/doomhamsters/Board.java
@@ -12,8 +12,7 @@ public class Board {
   private final List<Player> players;
   private final Deck deck;
   private final List<Card> discardPile;
-  private int currentIndex;
-  private int turnCount;
+  private int currentIndex, turnCount, extraTurns;
 
   /**
    * Creates a board for the supplied players and deck.
@@ -26,6 +25,7 @@ public class Board {
     this.deck = new Deck(new ArrayList<>(deck.getCards()));
     this.currentIndex = 0;
     this.turnCount = 0;
+    this.extraTurns = 0;
     this.discardPile = new ArrayList<>();
   }
 
@@ -41,6 +41,7 @@ public class Board {
     this.deck = new Deck(deck);
     this.currentIndex = other.currentIndex;
     this.turnCount = other.turnCount;
+    this.extraTurns = other.extraTurns;
 
     this.discardPile = new ArrayList<>();
     for (Card card : other.discardPile) {
@@ -99,12 +100,21 @@ public class Board {
   public List<Card> getDiscardPile() {
     return Collections.unmodifiableList(discardPile);
   }
-  /**
-   * Advances turn.
-   */
 
+  /**
+   * Advances the game turn to the next active player.
+   *
+   * <p>If extra turns are available, one extra turn is consumed and the
+   * current player keeps their turn instead of advancing to the next player.
+   */
   public void advanceTurn() {
+    if (extraTurns > 0) {
+      extraTurns--;
+      return;
+    }
+
     turnCount++;
+
     do {
       currentIndex = (currentIndex + 1) % players.size();
     } while (!players.get(currentIndex).isAlive());
@@ -126,5 +136,24 @@ public class Board {
    */
   public void setCurrentIndex(int index) {
     this.currentIndex = index;
+  }
+
+  /**
+   * Grants the current player an additional turn.
+   *
+   * <p>Extra turns are stacked and consumed one at a time when
+   * {@link #advanceTurn()} is called.
+   */
+  public void addExtraTurn() {
+    extraTurns++;
+  }
+
+  /**
+   * Returns the number of queued extra turns.
+   *
+   * @return queued extra turn count
+   */
+  public int getExtraTurns() {
+    return extraTurns;
   }
 }

--- a/src/test/java/com/doomhamsters/BoardTest.java
+++ b/src/test/java/com/doomhamsters/BoardTest.java
@@ -100,4 +100,41 @@ class BoardTest {
     Deck copiedDeck = board.getDeck();
     assertEquals(30, copiedDeck.getCards().size());
   }
+
+  @Test
+  @DisplayName("advanceTurn() consumes single extra turn")
+  void advanceTurnConsumesSingleExtraTurn() {
+    board.setCurrentIndex(0);
+
+    board.addExtraTurn();
+
+    board.advanceTurn();
+
+    assertEquals("Alice", board.getCurrentPlayer().getName());
+    assertEquals(0, board.getExtraTurns());
+
+    board.advanceTurn();
+
+    assertEquals("Bob", board.getCurrentPlayer().getName());
+  }
+
+  @Test
+  @DisplayName("advanceTurn() consumes stacked extra turns")
+  void advanceTurnConsumesStackedExtraTurns() {
+    board.setCurrentIndex(0);
+
+    board.addExtraTurn();
+    board.addExtraTurn();
+
+    board.advanceTurn();
+    assertEquals("Alice", board.getCurrentPlayer().getName());
+    assertEquals(1, board.getExtraTurns());
+
+    board.advanceTurn();
+    assertEquals("Alice", board.getCurrentPlayer().getName());
+    assertEquals(0, board.getExtraTurns());
+
+    board.advanceTurn();
+    assertEquals("Bob", board.getCurrentPlayer().getName());
+  }
 }


### PR DESCRIPTION
feat(board): add stacked extra turn support and resolve merge conflicts

- add extraTurns counter to Board
- add Board.addExtraTurn()
- update advanceTurn() to consume extra turns before advancing
- add getter for queued extra turns
- add tests for single and stacked extra turns
- resolve conflicts with development branch
- preserve restored game state rebinding logic
- remove final modifiers from players and deck
- fix JavaDoc indentation to now (hopefully🙏) pass checkstyle