### PR TITLE
Hamster combo 2 of a kind — steal random card

### DIFF
--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TwoHamstersCardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TwoHamstersCardDefinition.java
@@ -52,9 +52,9 @@ public class TwoHamstersCardDefinition implements CardDefinition {
 
     Player requester = context.getPlayer();
     Player target = context.getGame().getPlayers().stream()
-      .filter(p -> p.getId().equals(targetPlayerId))
-      .findFirst()
-      .orElseThrow(() -> new IllegalArgumentException(
+        .filter(p -> p.getId().equals(targetPlayerId))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
         "TwoHamsters: unknown targetPlayerId=" + targetPlayerId));
 
     if (target.getId().equals(requester.getId())) {
@@ -67,9 +67,9 @@ public class TwoHamstersCardDefinition implements CardDefinition {
 
     // 1. Die 2 Karten suchen
     List<Card> matchingCards = requester.getHand().stream()
-      .filter(c -> hamsterType.equalsIgnoreCase(c.getType()))
-      .limit(REQUIRED_COUNT)
-      .toList();
+        .filter(c -> hamsterType.equalsIgnoreCase(c.getType()))
+        .limit(REQUIRED_COUNT)
+        .toList();
 
     if (matchingCards.size() < REQUIRED_COUNT) {
       throw new IllegalStateException(String.format(
@@ -94,8 +94,8 @@ public class TwoHamstersCardDefinition implements CardDefinition {
 
     // 4. Resultat mit privateResult generieren
     String publicMsg = String.format(
-      "%s played two %s cards and stole a random card from %s!",
-      requester.getName(), hamsterType, target.getName());
+        "%s played two %s cards and stole a random card from %s!",
+        requester.getName(), hamsterType, target.getName());
 
     String privateMsg = "You successfully stole: " + stolenCard.getName();
 

--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TwoHamstersCardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TwoHamstersCardDefinition.java
@@ -1,0 +1,113 @@
+package com.doomhamsters.gamesession.cardcommands.cards;
+
+import com.doomhamsters.Card;
+import com.doomhamsters.Player;
+import com.doomhamsters.gamesession.cardcommands.CardCommandContext;
+import com.doomhamsters.gamesession.cardcommands.CardCommandResult;
+import com.doomhamsters.gamesession.cardcommands.CardDefinition;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.stereotype.Component;
+
+/**
+ * Card definition for playing 2 identical Hamsters to steal a random card.
+ */
+@Component
+public class TwoHamstersCardDefinition implements CardDefinition {
+
+  private static final int REQUIRED_COUNT = 2;
+
+  public TwoHamstersCardDefinition() {
+  }
+
+  @Override
+  public String cardType() {
+    return "hamster_two";
+  }
+
+  @Override
+  public String commandId() {
+    return "TWO_HAMSTERS";
+  }
+
+  @Override
+  public String displayName() {
+    return "Hamster Combo: 2-of-a-Kind";
+  }
+
+  @Override
+  public Card createTestingCard(String playerId) {
+    return new Card("two_hamsters_" + playerId, displayName(), cardType());
+  }
+
+  @Override
+  public CardCommandResult execute(CardCommandContext context) {
+    String targetPlayerId = requiredString(context, "targetPlayerId");
+    String hamsterType = requiredString(context, "hamsterType");
+
+    if (!hamsterType.startsWith("hamster_")) {
+      throw new IllegalArgumentException(
+        "TwoHamsters: hamsterType must start with 'hamster_', got: " + hamsterType);
+    }
+
+    Player requester = context.getPlayer();
+    Player target = context.getGame().getPlayers().stream()
+      .filter(p -> p.getId().equals(targetPlayerId))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException(
+        "TwoHamsters: unknown targetPlayerId=" + targetPlayerId));
+
+    if (target.getId().equals(requester.getId())) {
+      throw new IllegalArgumentException("TwoHamsters: cannot target yourself");
+    }
+
+    if (target.isEliminated()) {
+      throw new IllegalStateException("TwoHamsters: Target player is already eliminated.");
+    }
+
+    // 1. Die 2 Karten suchen
+    List<Card> matchingCards = requester.getHand().stream()
+      .filter(c -> hamsterType.equalsIgnoreCase(c.getType()))
+      .limit(REQUIRED_COUNT)
+      .toList();
+
+    if (matchingCards.size() < REQUIRED_COUNT) {
+      throw new IllegalStateException(String.format(
+        "TwoHamsters: requester does not hold %d cards of type %s",
+        REQUIRED_COUNT, hamsterType));
+    }
+
+    // 2. Die 2 Karten gefahrlos abwerfen
+    matchingCards.forEach(c -> requester.removeFromHand(c.getId()));
+
+    // 3. Steal-Logik (orientiert an StealCardDefinition)
+    if (target.getHand().isEmpty()) {
+      return CardCommandResult.publicOnly(
+        requester.getName() + " played two " + hamsterType + " cards, but "
+          + target.getName() + " had no cards to steal!");
+    }
+
+    int randomIndex = ThreadLocalRandom.current().nextInt(target.getHand().size());
+    Card cardToSteal = target.getHand().get(randomIndex);
+    Card stolenCard = target.removeFromHand(cardToSteal.getId());
+    requester.addToHand(stolenCard);
+
+    // 4. Resultat mit privateResult generieren
+    String publicMsg = String.format(
+      "%s played two %s cards and stole a random card from %s!",
+      requester.getName(), hamsterType, target.getName());
+
+    String privateMsg = "You successfully stole: " + stolenCard.getName();
+
+    return CardCommandResult.withPrivateResult(publicMsg, privateMsg, stolenCard);
+  }
+
+  // Hilfsmethode zum sicheren Auslesen der Parameter
+  private static String requiredString(CardCommandContext context, String key) {
+    Object value = context.getParameters().get(key);
+    if (value == null || value.toString().isBlank()) {
+      throw new IllegalArgumentException("TwoHamsters: missing required parameter: " + key);
+    }
+    return value.toString();
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TwoHamstersCardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TwoHamstersCardDefinition.java
@@ -22,7 +22,7 @@ public class TwoHamstersCardDefinition implements CardDefinition {
 
   @Override
   public String cardType() {
-    return "hamster_two";
+    return "HamsterTwo";
   }
 
   @Override

--- a/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
@@ -177,7 +177,7 @@ class GameControllerTest {
     assertEquals(31, testSession.getGame().getDeck().size());
     assertEquals(7, snackStashCardsInGame);
     testSession.getGame().getPlayers().forEach(player ->
-        assertEquals(10, player.getHand().size()));
+        assertEquals(11, player.getHand().size()));
   }
 
   @Test

--- a/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
@@ -177,7 +177,7 @@ class GameControllerTest {
     assertEquals(31, testSession.getGame().getDeck().size());
     assertEquals(7, snackStashCardsInGame);
     testSession.getGame().getPlayers().forEach(player ->
-        assertEquals(9, player.getHand().size()));
+        assertEquals(10, player.getHand().size()));
   }
 
   @Test

--- a/src/test/java/com/doomhamsters/gamesession/cardcommands/TwoHamstersCardDefinitionTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/cardcommands/TwoHamstersCardDefinitionTest.java
@@ -1,0 +1,211 @@
+package com.doomhamsters.gamesession.cardcommands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import com.doomhamsters.Card;
+import com.doomhamsters.Game;
+import com.doomhamsters.Player;
+import com.doomhamsters.gamesession.cardcommands.cards.TwoHamstersCardDefinition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TwoHamstersCardDefinitionTest {
+
+  private TwoHamstersCardDefinition definition;
+  private CardCommandContext context;
+  private Game game;
+  private Player requester;
+  private Player target;
+
+  @BeforeEach
+  void setUp() {
+    definition = new TwoHamstersCardDefinition();
+    context = mock(CardCommandContext.class);
+    game = mock(Game.class);
+    requester = mock(Player.class);
+    target = mock(Player.class);
+
+    when(context.getPlayer()).thenReturn(requester);
+    when(context.getGame()).thenReturn(game);
+
+    when(requester.getId()).thenReturn("req-123");
+    when(requester.getName()).thenReturn("Alice");
+
+    when(target.getId()).thenReturn("tgt-456");
+    when(target.getName()).thenReturn("Bob");
+    when(target.isEliminated()).thenReturn(false);
+
+    when(game.getPlayers()).thenReturn(List.of(requester, target));
+  }
+
+  @Test
+  void testMetadata() {
+    assertEquals("hamster_two", definition.cardType());
+    assertEquals("TWO_HAMSTERS", definition.commandId());
+    assertEquals("Hamster Combo: 2-of-a-Kind", definition.displayName());
+  }
+
+  @Test
+  void testCreateTestingCard() {
+    Card testingCard = definition.createTestingCard("player1");
+    assertNotNull(testingCard);
+    assertEquals("two_hamsters_player1", testingCard.getId());
+    assertEquals("Hamster Combo: 2-of-a-Kind", testingCard.getName());
+    assertEquals("hamster_two", testingCard.getType());
+  }
+
+  @Test
+  void testFailsIfTargetPlayerIdIsMissing() {
+    when(context.getParameters()).thenReturn(Map.of("hamsterType", "hamster_ninja"));
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: missing required parameter: targetPlayerId", exception.getMessage());
+  }
+
+  @Test
+  void testFailsIfHamsterTypeIsMissing() {
+    when(context.getParameters()).thenReturn(Map.of("targetPlayerId", "tgt-456"));
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: missing required parameter: hamsterType", exception.getMessage());
+  }
+
+  @Test
+  void testFailsIfHamsterTypeIsInvalid() {
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "tgt-456",
+      "hamsterType", "invalid_type"
+    ));
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: hamsterType must start with 'hamster_', got: invalid_type",
+      exception.getMessage());
+  }
+
+  @Test
+  void testFailsIfTargetIsUnknown() {
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "ghost-789",
+      "hamsterType", "hamster_ninja"
+    ));
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: unknown targetPlayerId=ghost-789", exception.getMessage());
+  }
+
+  @Test
+  void testFailsIfTargetIsSelf() {
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "req-123",
+      "hamsterType", "hamster_ninja"
+    ));
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: cannot target yourself", exception.getMessage());
+  }
+
+  @Test
+  void testFailsIfTargetIsEliminated() {
+    when(target.isEliminated()).thenReturn(true);
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "tgt-456",
+      "hamsterType", "hamster_ninja"
+    ));
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: Target player is already eliminated.", exception.getMessage());
+  }
+
+  @Test
+  void testFailsIfRequesterDoesNotHaveEnoughCards() {
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "tgt-456",
+      "hamsterType", "hamster_ninja"
+    ));
+
+    Card hamsterCard = new Card("card1", "Ninja", "hamster_ninja");
+    when(requester.getHand()).thenReturn(List.of(hamsterCard));
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: requester does not hold 2 cards of type hamster_ninja",
+      exception.getMessage());
+  }
+
+  @Test
+  void testReturnsPublicMessageIfTargetHasNoCards() {
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "tgt-456",
+      "hamsterType", "hamster_ninja"
+    ));
+
+    Card hamsterCard1 = new Card("card1", "Ninja", "hamster_ninja");
+    Card hamsterCard2 = new Card("card2", "Ninja", "hamster_ninja");
+    when(requester.getHand()).thenReturn(List.of(hamsterCard1, hamsterCard2));
+
+    when(target.getHand()).thenReturn(new ArrayList<>());
+
+    CardCommandResult result = definition.execute(context);
+
+    assertNotNull(result);
+    verify(requester, times(2)).removeFromHand(anyString());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"hamster_ninja", "hamster_viking", "hamster_wizard", "hamster_knight", "hamster_pirate"})
+  void testExecuteSuccessfullyStealsCardForAllHamsterTypes(String hamsterType) {
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "tgt-456",
+      "hamsterType", hamsterType
+    ));
+
+    Card hamsterCard1 = new Card("card1", "Hamster", hamsterType);
+    Card hamsterCard2 = new Card("card2", "Hamster", hamsterType);
+    when(requester.getHand()).thenReturn(List.of(hamsterCard1, hamsterCard2));
+
+    Card targetCard = new Card("targetCard1", "Valuable Loot", "loot");
+    when(target.getHand()).thenReturn(List.of(targetCard));
+    when(target.removeFromHand("targetCard1")).thenReturn(targetCard);
+
+    CardCommandResult result = definition.execute(context);
+
+    assertNotNull(result);
+    // Verifiziert, dass die zwei Kombo-Karten abgeworfen wurden
+    verify(requester, times(2)).removeFromHand(anyString());
+
+    // Verifiziert, dass eine Karte vom Target gestohlen wurde
+    verify(target, times(1)).removeFromHand(anyString());
+
+    // Verifiziert, dass der Requester die gestohlene Karte erhält
+    verify(requester, times(1)).addToHand(targetCard);
+  }
+  @Test
+  void testFailsIfParameterIsBlank() {
+    // Arrange: Der Parameter existiert, ist aber leer (Blank)
+    when(context.getParameters()).thenReturn(Map.of(
+      "targetPlayerId", "   ",
+      "hamsterType", "hamster_ninja"
+    ));
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> definition.execute(context));
+    assertEquals("TwoHamsters: missing required parameter: targetPlayerId", exception.getMessage());
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/cardcommands/TwoHamstersCardDefinitionTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/cardcommands/TwoHamstersCardDefinitionTest.java
@@ -51,7 +51,7 @@ class TwoHamstersCardDefinitionTest {
 
   @Test
   void testMetadata() {
-    assertEquals("hamster_two", definition.cardType());
+    assertEquals("HamsterTwo", definition.cardType()); // HIER ÄNDERN
     assertEquals("TWO_HAMSTERS", definition.commandId());
     assertEquals("Hamster Combo: 2-of-a-Kind", definition.displayName());
   }
@@ -62,7 +62,7 @@ class TwoHamstersCardDefinitionTest {
     assertNotNull(testingCard);
     assertEquals("two_hamsters_player1", testingCard.getId());
     assertEquals("Hamster Combo: 2-of-a-Kind", testingCard.getName());
-    assertEquals("hamster_two", testingCard.getType());
+    assertEquals("HamsterTwo", testingCard.getType()); // HIER ÄNDERN
   }
 
   @Test


### PR DESCRIPTION
## Description
This PR implements the backend logic for the "2-of-a-Kind Hamster Combo" feature, fulfilling the requirements for Issue #64. 

### Acceptance Criteria Met
Exactly 2 cards:** Implemented `TwoHamstersCardDefinition` which validates that exactly 2 cards of the same Hamster type are played together.
Reuse Steal Logic:** Successfully reused the proven random-steal logic (similar to Tiny Thief/StealCardDefinition) to transfer a random card from the target to the initiator.
Tests for all 5 Hamster types:** Added a `@ParameterizedTest` to rigorously test the execution logic across all five distinct Hamster variants (Ninja, Viking, Wizard, Knight, Pirate).

### Additional Quality Assurance
Achieved **100% Line and Branch Coverage** for the new `TwoHamstersCardDefinition` class.