### PR TITLE
Refactoring game session service

### DIFF
--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceCoordinator.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceCoordinator.java
@@ -1,0 +1,86 @@
+package com.doomhamsters.gamesession;
+
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Koordinator für die Hintergrund-Synchronisation der Spielsitzungen auf die Festplatte.
+ */
+@Component
+public class GameSessionPersistenceCoordinator {
+
+  private final GameSessionRepository repository;
+  private final GameSessionPersistenceService persistenceService;
+  private final Object monitor = new Object();
+  private boolean dirty;
+
+  /**
+   * Initialisiert den Koordinator und lädt gespeicherte Sitzungen.
+   *
+   * @param repository         Das Repository für die Datenhaltung im RAM
+   * @param persistenceService Der Handler für die Festplatten-Persistenz
+   */
+  public GameSessionPersistenceCoordinator(
+    GameSessionRepository repository,
+    GameSessionPersistenceService persistenceService) {
+    this.repository = repository;
+    this.persistenceService = persistenceService;
+    this.repository.loadAll(persistenceService.loadSessions());
+  }
+
+  /**
+   * Markiert den aktuellen Speicherstand als schmutzig (dirty), sodass er beim nächsten Flush gespeichert wird.
+   */
+  public void markDirty() {
+    synchronized (monitor) {
+      dirty = true;
+    }
+  }
+
+  /**
+   * Erzwingt ein sofortiges Speichern des aktuellen Standes auf die Festplatte.
+   */
+  public void saveNow() {
+    ConcurrentHashMap<String, GameSession> snapshot = repository.getAll();
+    synchronized (monitor) {
+      dirty = false;
+    }
+    executeSave(snapshot);
+  }
+
+  /**
+   * Persists pending session changes to disk on a timer instead of blocking every game action.
+   */
+  @Scheduled(fixedDelayString = "${doomhamsters.game.persistence-interval-ms:2000}")
+  public void flushDirtySessions() {
+    saveIfDirty();
+  }
+
+  @PreDestroy
+  public void flushSessionsOnShutdown() {
+    saveIfDirty();
+  }
+
+  private void saveIfDirty() {
+    ConcurrentHashMap<String, GameSession> snapshot;
+    synchronized (monitor) {
+      if (!dirty) {
+        return;
+      }
+      dirty = false;
+      snapshot = repository.getAll();
+    }
+    executeSave(snapshot);
+  }
+
+  private void executeSave(ConcurrentHashMap<String, GameSession> snapshot) {
+    try {
+      persistenceService.saveSessions(snapshot);
+    } catch (RuntimeException error) {
+      markDirty();
+      throw error;
+    }
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceCoordinator.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionPersistenceCoordinator.java
@@ -23,15 +23,16 @@ public class GameSessionPersistenceCoordinator {
    * @param persistenceService Der Handler für die Festplatten-Persistenz
    */
   public GameSessionPersistenceCoordinator(
-    GameSessionRepository repository,
-    GameSessionPersistenceService persistenceService) {
+      GameSessionRepository repository,
+      GameSessionPersistenceService persistenceService) {
     this.repository = repository;
     this.persistenceService = persistenceService;
     this.repository.loadAll(persistenceService.loadSessions());
   }
 
   /**
-   * Markiert den aktuellen Speicherstand als schmutzig (dirty), sodass er beim nächsten Flush gespeichert wird.
+   * Markiert den aktuellen Speicherstand als schmutzig (dirty),
+   * sodass er beim nächsten Flush gespeichert wird.
    */
   public void markDirty() {
     synchronized (monitor) {

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionRepository.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionRepository.java
@@ -1,0 +1,52 @@
+package com.doomhamsters.gamesession;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository zur in-memory Speicherung von Spielsitzungen.
+ */
+@Repository
+public class GameSessionRepository {
+
+  private final ConcurrentHashMap<String, GameSession> sessions = new ConcurrentHashMap<>();
+
+  /**
+   * Speichert eine Spielsitzung im Speicher.
+   *
+   * @param session Die zu speichernde Sitzung
+   */
+  public void store(GameSession session) {
+    sessions.put(session.getGameId(), session);
+  }
+
+  /**
+   * Ruft eine existierende Spielsitzung anhand ihrer ID ab.
+   *
+   * @param gameId Die ID der Sitzung
+   * @return Ein Optional, das die Sitzung enthält, falls gefunden
+   */
+  public Optional<GameSession> findById(String gameId) {
+    return Optional.ofNullable(sessions.get(gameId));
+  }
+
+  /**
+   * Gibt einen Snapshot aller aktuellen Spielsitzungen zurück.
+   *
+   * @return Eine Map aller Sitzungen
+   */
+  public ConcurrentHashMap<String, GameSession> getAll() {
+    return new ConcurrentHashMap<>(sessions);
+  }
+
+  /**
+   * Lädt initiale Sitzungen in den Speicher.
+   *
+   * @param loadedSessions Die zu ladenden Sitzungen
+   */
+  public void loadAll(Map<String, GameSession> loadedSessions) {
+    sessions.putAll(loadedSessions);
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionService.java
@@ -20,8 +20,8 @@ public class GameSessionService {
    * @param persistenceCoordinator Der Persistenz-Koordinator
    */
   public GameSessionService(
-    GameSessionRepository repository,
-    GameSessionPersistenceCoordinator persistenceCoordinator) {
+      GameSessionRepository repository,
+      GameSessionPersistenceCoordinator persistenceCoordinator) {
     this.repository = repository;
     this.persistenceCoordinator = persistenceCoordinator;
   }

--- a/src/main/java/com/doomhamsters/gamesession/GameSessionService.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameSessionService.java
@@ -1,10 +1,7 @@
 package com.doomhamsters.gamesession;
 
-import jakarta.annotation.PreDestroy;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 /**
@@ -13,22 +10,20 @@ import org.springframework.stereotype.Service;
 @Service
 public class GameSessionService {
 
-  private final ConcurrentHashMap<String, GameSession> sessions;
-
-  private final GameSessionPersistenceService persistenceService;
-  private final Object persistenceMonitor = new Object();
-  private boolean persistenceDirty;
+  private final GameSessionRepository repository;
+  private final GameSessionPersistenceCoordinator persistenceCoordinator;
 
   /**
-   * Initialisiert den Service und stellt gespeicherte Sitzungen wieder her.
+   * Initialisiert den Service mit seinen Abhängigkeiten.
    *
-   * @param persistenceService Der Handler für die Persistenz
+   * @param repository             Das in-memory Repository
+   * @param persistenceCoordinator Der Persistenz-Koordinator
    */
-  public GameSessionService(GameSessionPersistenceService persistenceService) {
-
-    this.persistenceService = persistenceService;
-
-    this.sessions = new ConcurrentHashMap<>(persistenceService.loadSessions());
+  public GameSessionService(
+    GameSessionRepository repository,
+    GameSessionPersistenceCoordinator persistenceCoordinator) {
+    this.repository = repository;
+    this.persistenceCoordinator = persistenceCoordinator;
   }
 
   /**
@@ -38,14 +33,11 @@ public class GameSessionService {
    * @return Die neu erstellte Spielsitzung
    */
   public GameSession createSession(String lobbyId) {
-
     String gameId = UUID.randomUUID().toString();
-
     GameSession newSession = new GameSession(gameId, lobbyId);
 
-    sessions.put(gameId, newSession);
-
-    persistSessionsNow();
+    repository.store(newSession);
+    persistenceCoordinator.saveNow();
 
     return newSession;
   }
@@ -57,8 +49,7 @@ public class GameSessionService {
    * @return Ein Optional, das die Sitzung enthält, falls gefunden
    */
   public Optional<GameSession> getSession(String gameId) {
-
-    return Optional.ofNullable(sessions.get(gameId));
+    return repository.findById(gameId);
   }
 
   /**
@@ -67,56 +58,7 @@ public class GameSessionService {
    * @param session Die zu speichernde Sitzung
    */
   public void saveSession(GameSession session) {
-
-    sessions.put(session.getGameId(), session);
-
-    markPersistenceDirty();
-  }
-
-  /**
-   * Persists pending session changes to disk on a timer instead of blocking every game action.
-   */
-  @Scheduled(fixedDelayString = "${doomhamsters.game.persistence-interval-ms:2000}")
-  void flushDirtySessions() {
-    persistSessionsIfDirty();
-  }
-
-  @PreDestroy
-  void flushSessionsOnShutdown() {
-    persistSessionsIfDirty();
-  }
-
-  private void markPersistenceDirty() {
-    synchronized (persistenceMonitor) {
-      persistenceDirty = true;
-    }
-  }
-
-  private void persistSessionsNow() {
-    ConcurrentHashMap<String, GameSession> snapshot = new ConcurrentHashMap<>(sessions);
-    persistenceService.saveSessions(snapshot);
-    synchronized (persistenceMonitor) {
-      persistenceDirty = false;
-    }
-  }
-
-  private void persistSessionsIfDirty() {
-    ConcurrentHashMap<String, GameSession> snapshot;
-    synchronized (persistenceMonitor) {
-      if (!persistenceDirty) {
-        return;
-      }
-      snapshot = new ConcurrentHashMap<>(sessions);
-      persistenceDirty = false;
-    }
-
-    try {
-      persistenceService.saveSessions(snapshot);
-    } catch (RuntimeException error) {
-      synchronized (persistenceMonitor) {
-        persistenceDirty = true;
-      }
-      throw error;
-    }
+    repository.store(session);
+    persistenceCoordinator.markDirty();
   }
 }

--- a/src/test/java/com/doomhamsters/gamesession/GameActionControllerTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameActionControllerTest.java
@@ -51,19 +51,23 @@ class GameActionControllerTest {
 
   @BeforeEach
   void setUp() {
-    gameSessionService =
-        new GameSessionService(
-            new GameSessionPersistenceService(
-                tempDir.resolve("game-action-sessions.json").toString()));
+    // 1. Die neuen Bauteile initialisieren
+    String sessionFilePath = tempDir.resolve("game-action-sessions.json").toString();
+    GameSessionPersistenceService persistenceService = new GameSessionPersistenceService(sessionFilePath);
+    GameSessionRepository repository = new GameSessionRepository();
+    GameSessionPersistenceCoordinator coordinator = new GameSessionPersistenceCoordinator(repository, persistenceService);
+
+    // 2. Den Service mit den Bauteilen zusammenbauen
+    gameSessionService = new GameSessionService(repository, coordinator);
 
     messagingTemplate = mock(SimpMessagingTemplate.class);
 
     controller =
-        new GameActionController(
-            gameSessionService,
-            new GameStateMapper(),
-            messagingTemplate,
-            new ObjectMapper());
+      new GameActionController(
+        gameSessionService,
+        new GameStateMapper(),
+        messagingTemplate,
+        new ObjectMapper());
   }
 
   @Test

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionPersistenceCoordinatorTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionPersistenceCoordinatorTest.java
@@ -1,0 +1,75 @@
+package com.doomhamsters.gamesession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GameSessionPersistenceCoordinatorTest {
+
+  private GameSessionRepository mockRepository;
+  private GameSessionPersistenceService mockPersistenceService;
+  private GameSessionPersistenceCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    mockRepository = mock(GameSessionRepository.class);
+    mockPersistenceService = mock(GameSessionPersistenceService.class);
+
+    when(mockPersistenceService.loadSessions()).thenReturn(new ConcurrentHashMap<>());
+    when(mockRepository.getAll()).thenReturn(new ConcurrentHashMap<>());
+
+    coordinator = new GameSessionPersistenceCoordinator(mockRepository, mockPersistenceService);
+  }
+
+  @Test
+  void testSaveNowForcesSave() {
+    coordinator.saveNow();
+    verify(mockPersistenceService, times(1)).saveSessions(any());
+  }
+
+  @Test
+  void testFlushCleanSessionsDoesNotPersist() {
+    coordinator.flushSessionsOnShutdown();
+    verify(mockPersistenceService, never()).saveSessions(any());
+  }
+
+  @Test
+  void testFlushDirtySessionsPersistsAndClearsFlag() {
+    coordinator.markDirty();
+    coordinator.flushDirtySessions();
+
+    verify(mockPersistenceService, times(1)).saveSessions(any());
+
+    coordinator.flushDirtySessions();
+    verify(mockPersistenceService, times(1)).saveSessions(any());
+  }
+
+  @Test
+  void testFailedFlushKeepsSessionsDirtyForRetry() {
+    coordinator.markDirty();
+    RuntimeException failure = new RuntimeException("Disk unavailable");
+
+    doThrow(failure).doNothing().when(mockPersistenceService).saveSessions(any());
+
+    RuntimeException thrown = assertThrows(
+      RuntimeException.class,
+      coordinator::flushDirtySessions
+    );
+    assertEquals(failure, thrown);
+
+    doNothing().when(mockPersistenceService).saveSessions(any());
+
+    coordinator.flushDirtySessions();
+    verify(mockPersistenceService, times(2)).saveSessions(any());
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionRepositoryTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.doomhamsters.gamesession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GameSessionRepositoryTest {
+
+  private GameSessionRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new GameSessionRepository();
+  }
+
+  @Test
+  void testStoreAndFindById() {
+    GameSession session = new GameSession("game-1", "lobby-1");
+    repository.store(session);
+
+    Optional<GameSession> retrieved = repository.findById("game-1");
+    assertTrue(retrieved.isPresent());
+    assertEquals("lobby-1", retrieved.get().getLobbyId());
+  }
+
+  @Test
+  void testFindByIdNotFound() {
+    Optional<GameSession> retrieved = repository.findById("non-existent");
+    assertFalse(retrieved.isPresent());
+  }
+
+  @Test
+  void testGetAllReturnsSnapshot() {
+    repository.store(new GameSession("game-1", "lobby-1"));
+
+    ConcurrentHashMap<String, GameSession> allSessions = repository.getAll();
+    assertEquals(1, allSessions.size());
+
+    allSessions.remove("game-1");
+    assertTrue(repository.findById("game-1").isPresent());
+  }
+
+  @Test
+  void testLoadAll() {
+    ConcurrentHashMap<String, GameSession> initialData = new ConcurrentHashMap<>();
+    initialData.put("game-1", new GameSession("game-1", "lobby-1"));
+
+    repository.loadAll(initialData);
+
+    assertTrue(repository.findById("game-1").isPresent());
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameSessionServiceTests.java
@@ -1,45 +1,30 @@
 package com.doomhamsters.gamesession;
 
-import static org.junit.jupiter.api.Assertions.*;
-import java.io.File;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class GameSessionServiceTests {
+class GameSessionServiceTest {
 
-  @TempDir
-  File tempDir;
-
-  private String filePath;
+  private GameSessionRepository mockRepository;
+  private GameSessionPersistenceCoordinator mockCoordinator;
   private GameSessionService service;
 
   @BeforeEach
   void setUp() {
-    filePath = new File(tempDir, "sessions.json").getAbsolutePath();
-    service = new GameSessionService(new GameSessionPersistenceService(filePath));
+    mockRepository = mock(GameSessionRepository.class);
+    mockCoordinator = mock(GameSessionPersistenceCoordinator.class);
+    service = new GameSessionService(mockRepository, mockCoordinator);
   }
 
   @Test
@@ -51,16 +36,20 @@ class GameSessionServiceTests {
     assertNotNull(session.getGameId());
     assertEquals(lobbyId, session.getLobbyId());
 
-    // Prüfen, ob sie wirklich in der Map ist
-    Optional<GameSession> retrieved = service.getSession(session.getGameId());
-    assertTrue(retrieved.isPresent());
-    assertEquals(session, retrieved.get());
+    verify(mockRepository, times(1)).store(any(GameSession.class));
+    verify(mockCoordinator, times(1)).saveNow();
   }
 
   @Test
-  void testGetSessionNotFound() {
-    Optional<GameSession> result = service.getSession("non-existent");
-    assertTrue(result.isEmpty());
+  void testGetSession() {
+    GameSession mockSession = new GameSession("game-1", "lobby-x");
+    when(mockRepository.findById("game-1")).thenReturn(Optional.of(mockSession));
+
+    Optional<GameSession> retrieved = service.getSession("game-1");
+
+    assertTrue(retrieved.isPresent());
+    assertEquals("lobby-x", retrieved.get().getLobbyId());
+    verify(mockRepository, times(1)).findById("game-1");
   }
 
   @Test
@@ -69,72 +58,7 @@ class GameSessionServiceTests {
 
     service.saveSession(session);
 
-    Optional<GameSession> retrieved = service.getSession("manual-id");
-    assertTrue(retrieved.isPresent());
-    assertEquals("lobby-x", retrieved.get().getLobbyId());
-  }
-
-  @Test
-  void testSessionsPersistAcrossServiceRestart() {
-
-    GameSession created =
-        service.createSession("persistent-lobby");
-
-    GameSessionService restartedService =
-        new GameSessionService(
-            new GameSessionPersistenceService(filePath));
-
-    Optional<GameSession> restored =
-        restartedService.getSession(
-            created.getGameId());
-
-    assertTrue(restored.isPresent());
-
-    assertEquals(
-        "persistent-lobby",
-        restored.get().getLobbyId());
-  }
-
-  @Test
-  void flushDirtySessionsPersistsSavedSession() {
-    GameSessionPersistenceService persistenceService = mock(GameSessionPersistenceService.class);
-    when(persistenceService.loadSessions()).thenReturn(new ConcurrentHashMap<>());
-    GameSessionService serviceWithMockPersistence = new GameSessionService(persistenceService);
-
-    serviceWithMockPersistence.saveSession(new GameSession("manual-id", "lobby-x"));
-    serviceWithMockPersistence.flushDirtySessions();
-    serviceWithMockPersistence.flushDirtySessions();
-
-    verify(persistenceService).saveSessions(any());
-  }
-
-  @Test
-  void flushCleanSessionsDoesNotPersist() {
-    GameSessionPersistenceService persistenceService = mock(GameSessionPersistenceService.class);
-    when(persistenceService.loadSessions()).thenReturn(new ConcurrentHashMap<>());
-    GameSessionService serviceWithMockPersistence = new GameSessionService(persistenceService);
-
-    serviceWithMockPersistence.flushSessionsOnShutdown();
-
-    verify(persistenceService, never()).saveSessions(any());
-  }
-
-  @Test
-  void failedFlushKeepsSessionsDirtyForRetry() {
-    GameSessionPersistenceService persistenceService = mock(GameSessionPersistenceService.class);
-    when(persistenceService.loadSessions()).thenReturn(new ConcurrentHashMap<>());
-    RuntimeException failure = new RuntimeException("disk unavailable");
-    doThrow(failure).doNothing().when(persistenceService).saveSessions(any());
-    GameSessionService serviceWithMockPersistence = new GameSessionService(persistenceService);
-    serviceWithMockPersistence.saveSession(new GameSession("manual-id", "lobby-x"));
-
-    RuntimeException thrown = assertThrows(
-        RuntimeException.class,
-        serviceWithMockPersistence::flushDirtySessions);
-
-    assertEquals(failure, thrown);
-    doNothing().when(persistenceService).saveSessions(any());
-    serviceWithMockPersistence.flushSessionsOnShutdown();
-    verify(persistenceService, times(2)).saveSessions(any());
+    verify(mockRepository, times(1)).store(eq(session));
+    verify(mockCoordinator, times(1)).markDirty();
   }
 }

--- a/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
+++ b/src/test/java/com/doomhamsters/gamesession/dto/GameStateControllerTests.java
@@ -6,12 +6,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.doomhamsters.Card;
 import com.doomhamsters.gamesession.GameSession;
+import com.doomhamsters.gamesession.GameSessionPersistenceCoordinator;
 import com.doomhamsters.gamesession.GameSessionPersistenceService;
+import com.doomhamsters.gamesession.GameSessionRepository;
 import com.doomhamsters.gamesession.GameSessionService;
-import com.doomhamsters.gamesession.dto.GameStateMapper;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,21 +31,18 @@ class GameStateControllerTests {
   @BeforeEach
   void setUp() {
     String filePath = new File(tempDir, "sessions.json").getAbsolutePath();
-    gameSessionService =
-        new GameSessionService(
-            new GameSessionPersistenceService(filePath));
 
-    GameStateMapper mapper =
-        new GameStateMapper();
+    GameSessionPersistenceService persistenceService = new GameSessionPersistenceService(filePath);
+    GameSessionRepository repository = new GameSessionRepository();
+    GameSessionPersistenceCoordinator coordinator = new GameSessionPersistenceCoordinator(repository, persistenceService);
 
-    GameStateController controller =
-        new GameStateController(
-            gameSessionService,
-            mapper);
+    gameSessionService = new GameSessionService(repository, coordinator);
 
-    mockMvc =
-        MockMvcBuilders.standaloneSetup(controller)
-            .build();
+    GameStateMapper mapper = new GameStateMapper();
+
+    GameStateController controller = new GameStateController(gameSessionService, mapper);
+
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
   }
 
   @Test


### PR DESCRIPTION
Description
This PR refactors the GameSessionService to resolve the "God Class" anti-pattern, fulfilling the requirements for Issue #78.

Acceptance Criteria Met
Extract unrelated logic: Successfully extracted in-memory storage into a dedicated GameSessionRepository and complex thread-locking/scheduled persistence into a GameSessionPersistenceCoordinator.
Single Responsibility: The GameSessionService is now strictly focused on its core domain, acting as a lightweight facade that simply orchestrates the repository and coordinator.

Additional Quality Assurance
Removed the monolithic test suite and introduced highly focused, isolated unit tests for the newly separated architecture components (GameSessionRepositoryTest, GameSessionPersistenceCoordinatorTest).
Updated @BeforeEach setups in existing controller tests to accommodate the new dependency injection structure, ensuring all existing tests continue to pass successfully.