### PR TITLE
Central STOMP error events for rejected actions

### DIFF
--- a/src/main/java/com/doomhamsters/gamesession/GameActionController.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameActionController.java
@@ -12,15 +12,20 @@ import com.doomhamsters.gamesession.cardcommands.CardDefinition;
 import com.doomhamsters.gamesession.cardcommands.CardRegistry;
 import com.doomhamsters.gamesession.dto.CardDto;
 import com.doomhamsters.gamesession.dto.DoomDrawnEventDto;
+import com.doomhamsters.gamesession.dto.ErrorEventDto;
 import com.doomhamsters.gamesession.dto.GameStateDto;
 import com.doomhamsters.gamesession.dto.GameStateMapper;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 import tools.jackson.core.JacksonException;
@@ -518,5 +523,71 @@ public class GameActionController {
             Player::getId,
             player -> player.getHand().size()))
         .toString();
+  }
+
+  /**
+   * Reports a rejected game action back to the originating player.
+   *
+   * <p>Catches expected validation failures from this controller's message mappings, logs them at
+   * WARN, and sends a private error event to {@code /queue/game/{gameId}/{playerId}/errors}.
+   *
+   * @param exception the validation failure
+   * @param message the original STOMP message
+   */
+  @MessageExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+  public void handleInvalidAction(RuntimeException exception, Message<?> message) {
+    SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(message);
+    String gameId = extractGameId(accessor.getDestination());
+    String playerId = extractPlayerIdOrNull(message.getPayload());
+
+    String code = (exception instanceof IllegalStateException) ? "ILLEGAL_STATE" : "INVALID_ACTION";
+
+    LOGGER.warn(
+        "rejected action: gameId={}, playerId={}, code={}, reason={}",
+        gameId,
+        playerId,
+        code,
+        exception.getMessage());
+
+    if (gameId == null || playerId == null) {
+      return;
+    }
+
+    messagingTemplate.convertAndSend(
+        "/queue/game/" + gameId + "/" + playerId + "/errors",
+        new ErrorEventDto(code, exception.getMessage(), gameId));
+  }
+
+  private String extractGameId(String destination) {
+    if (destination == null) {
+      return null;
+    }
+
+    String[] parts = destination.split("/");
+    for (int index = 0; index < parts.length - 1; index++) {
+      if ("game".equals(parts[index])) {
+        return parts[index + 1];
+      }
+    }
+
+    return null;
+  }
+
+  private String extractPlayerIdOrNull(Object payload) {
+    String json;
+    if (payload instanceof byte[] bytes) {
+      json = new String(bytes, StandardCharsets.UTF_8);
+    } else if (payload instanceof String text) {
+      json = text;
+    } else {
+      return null;
+    }
+
+    try {
+      JsonNode playerId = objectMapper.readTree(json).get("playerId");
+      return (playerId != null && playerId.isTextual()) ? playerId.asText() : null;
+    } catch (JacksonException exception) {
+      return null;
+    }
   }
 }

--- a/src/main/java/com/doomhamsters/gamesession/GameActionController.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameActionController.java
@@ -12,6 +12,7 @@ import com.doomhamsters.gamesession.cardcommands.CardDefinition;
 import com.doomhamsters.gamesession.cardcommands.CardRegistry;
 import com.doomhamsters.gamesession.dto.CardDto;
 import com.doomhamsters.gamesession.dto.DoomDrawnEventDto;
+import com.doomhamsters.gamesession.dto.ErrorCode;
 import com.doomhamsters.gamesession.dto.ErrorEventDto;
 import com.doomhamsters.gamesession.dto.GameStateDto;
 import com.doomhamsters.gamesession.dto.GameStateMapper;
@@ -540,7 +541,9 @@ public class GameActionController {
     String gameId = extractGameId(accessor.getDestination());
     String playerId = extractPlayerIdOrNull(message.getPayload());
 
-    String code = (exception instanceof IllegalStateException) ? "ILLEGAL_STATE" : "INVALID_ACTION";
+    ErrorCode code = (exception instanceof IllegalStateException)
+        ? ErrorCode.ILLEGAL_STATE
+        : ErrorCode.INVALID_ACTION;
 
     LOGGER.warn(
         "rejected action: gameId={}, playerId={}, code={}, reason={}",
@@ -580,6 +583,9 @@ public class GameActionController {
     } else if (payload instanceof String text) {
       json = text;
     } else {
+      LOGGER.warn(
+          "Unsupported payload type for error routing: {}",
+          payload == null ? "null" : payload.getClass().getName());
       return null;
     }
 

--- a/src/main/java/com/doomhamsters/gamesession/dto/ErrorCode.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.doomhamsters.gamesession.dto;
+
+/**
+ * Machine-readable error codes sent to a player when a game action is rejected.
+ */
+public enum ErrorCode {
+  INVALID_ACTION,
+  ILLEGAL_STATE
+}

--- a/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
@@ -27,27 +27,47 @@ public class ErrorEventDto {
     this.timestamp = Instant.now().toString();
   }
 
-  /** @return event type constant */
+  /**
+   * Returns the event type.
+   *
+   * @return event type constant
+   */
   public String getType() {
     return type;
   }
 
-  /** @return short machine-readable error code */
+  /**
+   * Returns the machine-readable error code.
+   *
+   * @return short machine-readable error code
+   */
   public String getCode() {
     return code;
   }
 
-  /** @return human-readable reason the action was rejected */
+  /**
+   * Returns the human-readable rejection reason.
+   *
+   * @return reason the action was rejected
+   */
   public String getMessage() {
     return message;
   }
 
-  /** @return the affected game session */
+  /**
+   * Returns the affected game session.
+   *
+   * @return the affected game session id
+   */
   public String getGameId() {
     return gameId;
   }
 
-  /** @return ISO-8601 creation time */
+  /**
+   * Returns the creation time.
+   *
+   * @return ISO-8601 creation time
+   */
   public String getTimestamp() {
     return timestamp;
   }

--- a/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  */
 public class ErrorEventDto {
 
-  private final String type = "GAME_ERROR";
+  private static final String TYPE = "GAME_ERROR";
   private final String code;
   private final String message;
   private final String gameId;
@@ -33,7 +33,7 @@ public class ErrorEventDto {
    * @return event type constant
    */
   public String getType() {
-    return type;
+    return TYPE;
   }
 
   /**

--- a/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 public class ErrorEventDto {
 
   private static final String TYPE = "GAME_ERROR";
-  private final String code;
+  private final ErrorCode code;
   private final String message;
   private final String gameId;
   private final String timestamp;
@@ -20,7 +20,7 @@ public class ErrorEventDto {
    * @param message human-readable reason the action was rejected
    * @param gameId the affected game session
    */
-  public ErrorEventDto(String code, String message, String gameId) {
+  public ErrorEventDto(ErrorCode code, String message, String gameId) {
     this.code = code;
     this.message = message;
     this.gameId = gameId;
@@ -39,9 +39,9 @@ public class ErrorEventDto {
   /**
    * Returns the machine-readable error code.
    *
-   * @return short machine-readable error code
+   * @return the error code
    */
-  public String getCode() {
+  public ErrorCode getCode() {
     return code;
   }
 

--- a/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
+++ b/src/main/java/com/doomhamsters/gamesession/dto/ErrorEventDto.java
@@ -1,0 +1,54 @@
+package com.doomhamsters.gamesession.dto;
+
+import java.time.Instant;
+
+/**
+ * Player-private error event sent when a game action is rejected.
+ */
+public class ErrorEventDto {
+
+  private final String type = "GAME_ERROR";
+  private final String code;
+  private final String message;
+  private final String gameId;
+  private final String timestamp;
+
+  /**
+   * Creates an error event.
+   *
+   * @param code short machine-readable error code
+   * @param message human-readable reason the action was rejected
+   * @param gameId the affected game session
+   */
+  public ErrorEventDto(String code, String message, String gameId) {
+    this.code = code;
+    this.message = message;
+    this.gameId = gameId;
+    this.timestamp = Instant.now().toString();
+  }
+
+  /** @return event type constant */
+  public String getType() {
+    return type;
+  }
+
+  /** @return short machine-readable error code */
+  public String getCode() {
+    return code;
+  }
+
+  /** @return human-readable reason the action was rejected */
+  public String getMessage() {
+    return message;
+  }
+
+  /** @return the affected game session */
+  public String getGameId() {
+    return gameId;
+  }
+
+  /** @return ISO-8601 creation time */
+  public String getTimestamp() {
+    return timestamp;
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/GameActionControllerErrorHandlingTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameActionControllerErrorHandlingTest.java
@@ -1,0 +1,92 @@
+package com.doomhamsters.gamesession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.doomhamsters.gamesession.dto.ErrorEventDto;
+import com.doomhamsters.gamesession.dto.GameStateMapper;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.support.MessageBuilder;
+import tools.jackson.databind.ObjectMapper;
+
+class GameActionControllerErrorHandlingTest {
+
+  private SimpMessagingTemplate messagingTemplate;
+
+  private GameActionController controller;
+
+  @BeforeEach
+  void setUp() {
+    messagingTemplate = mock(SimpMessagingTemplate.class);
+
+    controller =
+        new GameActionController(
+            mock(GameSessionService.class),
+            new GameStateMapper(),
+            messagingTemplate,
+            new ObjectMapper());
+  }
+
+  @Test
+  void rejectedActionSendsErrorEventToOriginatingPlayer() {
+    Message<byte[]> message = actionMessage("/app/game/g1/draw", "{\"playerId\":\"p1\"}");
+
+    controller.handleInvalidAction(
+        new IllegalArgumentException("It is not player p1's turn."), message);
+
+    ArgumentCaptor<ErrorEventDto> captor = ArgumentCaptor.forClass(ErrorEventDto.class);
+    verify(messagingTemplate).convertAndSend(
+        eq("/queue/game/g1/p1/errors"),
+        captor.capture());
+
+    ErrorEventDto event = captor.getValue();
+    assertEquals("GAME_ERROR", event.getType());
+    assertEquals("INVALID_ACTION", event.getCode());
+    assertEquals("g1", event.getGameId());
+    assertEquals("It is not player p1's turn.", event.getMessage());
+  }
+
+  @Test
+  void illegalStateUsesIllegalStateCode() {
+    Message<byte[]> message = actionMessage("/app/game/g1/nextTurn", "{\"playerId\":\"p1\"}");
+
+    controller.handleInvalidAction(
+        new IllegalStateException("Doom resolution must be acknowledged before playing cards."),
+        message);
+
+    ArgumentCaptor<ErrorEventDto> captor = ArgumentCaptor.forClass(ErrorEventDto.class);
+    verify(messagingTemplate).convertAndSend(
+        eq("/queue/game/g1/p1/errors"),
+        captor.capture());
+
+    assertEquals("ILLEGAL_STATE", captor.getValue().getCode());
+  }
+
+  @Test
+  void malformedPayloadIsLoggedButNotRouted() {
+    Message<byte[]> message = actionMessage("/app/game/g1/draw", "not valid json");
+
+    controller.handleInvalidAction(new IllegalArgumentException("Action payload must be valid JSON."),
+        message);
+
+    verify(messagingTemplate, never()).convertAndSend(anyString(), any(ErrorEventDto.class));
+  }
+
+  private Message<byte[]> actionMessage(String destination, String payload) {
+    return MessageBuilder
+        .withPayload(payload.getBytes(StandardCharsets.UTF_8))
+        .setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, destination)
+        .build();
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/GameActionControllerErrorHandlingTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameActionControllerErrorHandlingTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.doomhamsters.gamesession.dto.ErrorCode;
 import com.doomhamsters.gamesession.dto.ErrorEventDto;
 import com.doomhamsters.gamesession.dto.GameStateMapper;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +53,7 @@ class GameActionControllerErrorHandlingTest {
 
     ErrorEventDto event = captor.getValue();
     assertEquals("GAME_ERROR", event.getType());
-    assertEquals("INVALID_ACTION", event.getCode());
+    assertEquals(ErrorCode.INVALID_ACTION, event.getCode());
     assertEquals("g1", event.getGameId());
     assertEquals("It is not player p1's turn.", event.getMessage());
   }
@@ -70,7 +71,7 @@ class GameActionControllerErrorHandlingTest {
         eq("/queue/game/g1/p1/errors"),
         captor.capture());
 
-    assertEquals("ILLEGAL_STATE", captor.getValue().getCode());
+    assertEquals(ErrorCode.ILLEGAL_STATE, captor.getValue().getCode());
   }
 
   @Test
@@ -79,6 +80,38 @@ class GameActionControllerErrorHandlingTest {
 
     controller.handleInvalidAction(new IllegalArgumentException("Action payload must be valid JSON."),
         message);
+
+    verify(messagingTemplate, never()).convertAndSend(anyString(), any(ErrorEventDto.class));
+  }
+
+  @Test
+  void missingDestinationIsNotRouted() {
+    Message<byte[]> message = MessageBuilder
+        .withPayload("{\"playerId\":\"p1\"}".getBytes(StandardCharsets.UTF_8))
+        .build();
+
+    controller.handleInvalidAction(new IllegalArgumentException("boom"), message);
+
+    verify(messagingTemplate, never()).convertAndSend(anyString(), any(ErrorEventDto.class));
+  }
+
+  @Test
+  void missingPlayerIdIsNotRouted() {
+    Message<byte[]> message = actionMessage("/app/game/g1/draw", "{}");
+
+    controller.handleInvalidAction(new IllegalArgumentException("boom"), message);
+
+    verify(messagingTemplate, never()).convertAndSend(anyString(), any(ErrorEventDto.class));
+  }
+
+  @Test
+  void unsupportedPayloadTypeIsNotRouted() {
+    Message<Integer> message = MessageBuilder
+        .withPayload(123)
+        .setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/app/game/g1/draw")
+        .build();
+
+    controller.handleInvalidAction(new IllegalArgumentException("boom"), message);
 
     verify(messagingTemplate, never()).convertAndSend(anyString(), any(ErrorEventDto.class));
   }


### PR DESCRIPTION
Adds a central exception handler so the player gets a private error event when a game action is rejected, instead of failing silently.

- New ErrorEventDto (code, message, gameId, timestamp)
- @MessageExceptionHandler in GameActionController sends the error to /queue/game/{gameId}/{playerId}/errors, logged at WARN
- Tests cover the error event, the ILLEGAL_STATE code, and a malformed payload

Closes #85