### PR TITLE
Global REST error handler with unified body

### DIFF
--- a/src/main/java/com/doomhamsters/web/ApiErrorDto.java
+++ b/src/main/java/com/doomhamsters/web/ApiErrorDto.java
@@ -1,0 +1,76 @@
+package com.doomhamsters.web;
+
+import java.time.Instant;
+
+/**
+ * Unified error response body returned by the REST endpoints.
+ */
+public class ApiErrorDto {
+
+  private final String timestamp;
+  private final int status;
+  private final String error;
+  private final String message;
+  private final String path;
+
+  /**
+   * Creates a REST error body.
+   *
+   * @param status HTTP status code
+   * @param error short status reason phrase
+   * @param message human-readable detail
+   * @param path the request URI that caused the error
+   */
+  public ApiErrorDto(int status, String error, String message, String path) {
+    this.timestamp = Instant.now().toString();
+    this.status = status;
+    this.error = error;
+    this.message = message;
+    this.path = path;
+  }
+
+  /**
+   * Returns the creation time.
+   *
+   * @return ISO-8601 creation time
+   */
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Returns the HTTP status code.
+   *
+   * @return HTTP status code
+   */
+  public int getStatus() {
+    return status;
+  }
+
+  /**
+   * Returns the short status reason phrase.
+   *
+   * @return status reason phrase
+   */
+  public String getError() {
+    return error;
+  }
+
+  /**
+   * Returns the human-readable detail message.
+   *
+   * @return detail message
+   */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Returns the request URI that caused the error.
+   *
+   * @return request path
+   */
+  public String getPath() {
+    return path;
+  }
+}

--- a/src/main/java/com/doomhamsters/web/RestExceptionHandler.java
+++ b/src/main/java/com/doomhamsters/web/RestExceptionHandler.java
@@ -1,0 +1,97 @@
+package com.doomhamsters.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+/**
+ * Maps uncaught exceptions from the REST endpoints to a unified {@link ApiErrorDto} body.
+ *
+ * <p>Spring's own MVC exceptions (such as method-not-allowed or an unreadable body) keep their
+ * original status code and are rendered through {@link #handleExceptionInternal}, so they are
+ * never masked as 500.
+ */
+@RestControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RestExceptionHandler.class);
+
+  /**
+   * Maps invalid client input to 400 Bad Request.
+   *
+   * @param exception the offending exception
+   * @param request the current request
+   * @return a 400 error body
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ApiErrorDto> handleBadRequest(
+      IllegalArgumentException exception, HttpServletRequest request) {
+
+    LOGGER.warn("bad request: path={}, reason={}", request.getRequestURI(), exception.getMessage());
+    return build(HttpStatus.BAD_REQUEST, exception.getMessage(), request.getRequestURI());
+  }
+
+  /**
+   * Maps an illegal state (an action not allowed right now) to 409 Conflict.
+   *
+   * @param exception the offending exception
+   * @param request the current request
+   * @return a 409 error body
+   */
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<ApiErrorDto> handleConflict(
+      IllegalStateException exception, HttpServletRequest request) {
+
+    LOGGER.warn("conflict: path={}, reason={}", request.getRequestURI(), exception.getMessage());
+    return build(HttpStatus.CONFLICT, exception.getMessage(), request.getRequestURI());
+  }
+
+  /**
+   * Maps any other unexpected error to 500 Internal Server Error.
+   *
+   * @param exception the offending exception
+   * @param request the current request
+   * @return a 500 error body
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiErrorDto> handleUnexpected(
+      Exception exception, HttpServletRequest request) {
+
+    LOGGER.error("unexpected error: path={}", request.getRequestURI(), exception);
+    return build(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred.",
+        request.getRequestURI());
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleExceptionInternal(
+      Exception ex,
+      Object body,
+      HttpHeaders headers,
+      HttpStatusCode statusCode,
+      WebRequest request) {
+
+    String path = (request instanceof ServletWebRequest servletRequest)
+        ? servletRequest.getRequest().getRequestURI()
+        : "";
+    HttpStatus status = HttpStatus.valueOf(statusCode.value());
+    LOGGER.warn("request error: status={}, path={}, reason={}",
+        statusCode.value(), path, ex.getMessage());
+    ApiErrorDto apiError =
+        new ApiErrorDto(statusCode.value(), status.getReasonPhrase(), ex.getMessage(), path);
+    return new ResponseEntity<>(apiError, headers, statusCode);
+  }
+
+  private ResponseEntity<ApiErrorDto> build(HttpStatus status, String message, String path) {
+    ApiErrorDto body = new ApiErrorDto(status.value(), status.getReasonPhrase(), message, path);
+    return ResponseEntity.status(status).body(body);
+  }
+}

--- a/src/test/java/com/doomhamsters/web/RestExceptionHandlerTest.java
+++ b/src/test/java/com/doomhamsters/web/RestExceptionHandlerTest.java
@@ -1,0 +1,81 @@
+package com.doomhamsters.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.ServletWebRequest;
+
+class RestExceptionHandlerTest {
+
+  private final RestExceptionHandler handler = new RestExceptionHandler();
+
+  @Test
+  void illegalArgumentMapsToBadRequest() {
+    ResponseEntity<ApiErrorDto> response =
+        handler.handleBadRequest(new IllegalArgumentException("bad input"), request("/api/lobby/create"));
+
+    assertEquals(400, response.getStatusCode().value());
+    ApiErrorDto body = response.getBody();
+    assertNotNull(body);
+    assertEquals(400, body.getStatus());
+    assertEquals("Bad Request", body.getError());
+    assertEquals("bad input", body.getMessage());
+    assertEquals("/api/lobby/create", body.getPath());
+    assertNotNull(body.getTimestamp());
+  }
+
+  @Test
+  void illegalStateMapsToConflict() {
+    ResponseEntity<ApiErrorDto> response =
+        handler.handleConflict(new IllegalStateException("game already started"),
+            request("/api/lobby/abc/join"));
+
+    assertEquals(409, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertEquals("Conflict", response.getBody().getError());
+    assertEquals("game already started", response.getBody().getMessage());
+  }
+
+  @Test
+  void unexpectedMapsToInternalServerError() {
+    ResponseEntity<ApiErrorDto> response =
+        handler.handleUnexpected(new RuntimeException("kaboom"), request("/api/game/g1/state"));
+
+    assertEquals(500, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertEquals("Internal Server Error", response.getBody().getError());
+  }
+
+  @Test
+  void frameworkExceptionKeepsStatusWithUnifiedBody() {
+    HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+    when(httpRequest.getRequestURI()).thenReturn("/api/lobby/create");
+
+    ResponseEntity<Object> response = handler.handleExceptionInternal(
+        new RuntimeException("method not allowed"),
+        null,
+        new HttpHeaders(),
+        HttpStatus.METHOD_NOT_ALLOWED,
+        new ServletWebRequest(httpRequest));
+
+    assertEquals(405, response.getStatusCode().value());
+    ApiErrorDto body = (ApiErrorDto) response.getBody();
+    assertNotNull(body);
+    assertEquals(405, body.getStatus());
+    assertEquals("Method Not Allowed", body.getError());
+    assertEquals("/api/lobby/create", body.getPath());
+  }
+
+  private HttpServletRequest request(String uri) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRequestURI()).thenReturn(uri);
+    return request;
+  }
+}


### PR DESCRIPTION
Adds a global exception handler so the REST endpoints return a consistent error body instead of Spring's default page.

- New ApiErrorDto (timestamp, status, error, message, path)
- @RestControllerAdvice maps errors to the right status: 400 bad request, 409 conflict, 500 for anything unexpected — and Spring's own errors (e.g. 405) keep their status and use the same body
- Tests cover the 400/409/500 paths and the framework-error path

Closes #86 