### PR TITLE
Tunnel chaos — shuffle the deck

### DIFF
--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TunnelChaosCardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/TunnelChaosCardDefinition.java
@@ -1,0 +1,55 @@
+package com.doomhamsters.gamesession.cardcommands.cards;
+
+import com.doomhamsters.Card;
+import com.doomhamsters.gamesession.cardcommands.CardCommandContext;
+import com.doomhamsters.gamesession.cardcommands.CardCommandResult;
+import com.doomhamsters.gamesession.cardcommands.CardDefinition;
+import org.springframework.stereotype.Component;
+
+/**
+ * Card definition for Tunnel Chaos.
+ *
+ * <p>Activating the card shuffles the draw deck and announces the effect to all players. The card
+ * has no target and produces no private information.
+ */
+@Component
+public class TunnelChaosCardDefinition implements CardDefinition {
+
+  /**
+   * Creates the Tunnel Chaos card definition.
+   */
+  public TunnelChaosCardDefinition() {
+    // Required by Spring component scanning for this stateless card definition.
+  }
+
+  @Override
+  public String cardType() {
+    return "TunnelChaos";
+  }
+
+  @Override
+  public String commandId() {
+    return "TUNNEL_CHAOS";
+  }
+
+  @Override
+  public String displayName() {
+    return "Tunnel Chaos";
+  }
+
+  @Override
+  public Card createTestingCard(String playerId) {
+    return new Card(
+        "tunnel_chaos_" + playerId,
+        displayName(),
+        cardType());
+  }
+
+  @Override
+  public CardCommandResult execute(CardCommandContext context) {
+    context.getGame().getDeck().shuffle();
+
+    return CardCommandResult.publicOnly(
+        context.getPlayer().getName() + " activated Tunnel Chaos and shuffled the deck.");
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
@@ -177,7 +177,7 @@ class GameControllerTest {
     assertEquals(31, testSession.getGame().getDeck().size());
     assertEquals(7, snackStashCardsInGame);
     testSession.getGame().getPlayers().forEach(player ->
-        assertEquals(16, player.getHand().size()));
+        assertEquals(17, player.getHand().size()));
   }
 
   @Test

--- a/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
@@ -177,7 +177,7 @@ class GameControllerTest {
     assertEquals(31, testSession.getGame().getDeck().size());
     assertEquals(7, snackStashCardsInGame);
     testSession.getGame().getPlayers().forEach(player ->
-        assertEquals(15, player.getHand().size()));
+        assertEquals(16, player.getHand().size()));
   }
 
   @Test
@@ -199,6 +199,9 @@ class GameControllerTest {
       long sniffAheadCount = player.getHand().stream()
           .filter(card -> "SniffAhead".equals(card.getType()))
           .count();
+      long tunnelChaosCount = player.getHand().stream()
+          .filter(card -> "TunnelChaos".equals(card.getType()))
+          .count();
       long stablePowerNapIdCount = player.getHand().stream()
           .filter(card -> ("power_nap_" + player.getId()).equals(card.getId()))
           .filter(card -> "Power Nap".equals(card.getName()))
@@ -211,13 +214,19 @@ class GameControllerTest {
           .filter(card -> ("sniff_ahead_" + player.getId()).equals(card.getId()))
           .filter(card -> "Sniff Ahead".equals(card.getName()))
           .count();
+      long stableTunnelChaosIdCount = player.getHand().stream()
+          .filter(card -> ("tunnel_chaos_" + player.getId()).equals(card.getId()))
+          .filter(card -> "Tunnel Chaos".equals(card.getName()))
+          .count();
 
       assertEquals(1, powerNapCount);
       assertEquals(1, quickPeekCount);
       assertEquals(1, sniffAheadCount);
+      assertEquals(1, tunnelChaosCount);
       assertEquals(1, stablePowerNapIdCount);
       assertEquals(1, stableQuickPeekIdCount);
       assertEquals(1, stableSniffAheadIdCount);
+      assertEquals(1, stableTunnelChaosIdCount);
     });
   }
 

--- a/src/test/java/com/doomhamsters/gamesession/cardcommands/cards/TunnelChaosCardDefinitionTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/cardcommands/cards/TunnelChaosCardDefinitionTest.java
@@ -1,0 +1,106 @@
+package com.doomhamsters.gamesession.cardcommands.cards;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.doomhamsters.Card;
+import com.doomhamsters.Deck;
+import com.doomhamsters.Game;
+import com.doomhamsters.Player;
+import com.doomhamsters.gamesession.GameSession;
+import com.doomhamsters.gamesession.cardcommands.CardCommandContext;
+import com.doomhamsters.gamesession.cardcommands.CardCommandResult;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TunnelChaosCardDefinitionTest {
+
+  private static final TunnelChaosCardDefinition DEFINITION = new TunnelChaosCardDefinition();
+
+  private GameSession session;
+  private Game game;
+  private Player player;
+  private Card tunnelCard;
+
+  @BeforeEach
+  void setUp() {
+    session = new GameSession("game-1", "lobby-1");
+    game = session.getGame();
+    player = new Player("p1", "Alice");
+    tunnelCard = new Card("tunnel_chaos_p1", DEFINITION.displayName(), DEFINITION.cardType());
+
+    List<Card> deckCards = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      deckCards.add(new Card("normal_" + i, "Normal", "normal"));
+    }
+    game.setDeck(new Deck(deckCards));
+  }
+
+  private CardCommandContext ctx() {
+    return new CardCommandContext(session, game, player, tunnelCard, Map.of());
+  }
+
+  // ── metadata ─────────────────────────────────────────────────────
+
+  @Test
+  void cardType_matchesExpected() {
+    assertEquals("TunnelChaos", DEFINITION.cardType());
+  }
+
+  @Test
+  void commandId_matchesExpected() {
+    assertEquals("TUNNEL_CHAOS", DEFINITION.commandId());
+  }
+
+  @Test
+  void effectId_defaultsToCommandId() {
+    assertEquals(DEFINITION.commandId(), DEFINITION.effectId());
+  }
+
+  @Test
+  void createTestingCard_containsPlayerId() {
+    Card card = DEFINITION.createTestingCard("p1");
+    assertTrue(card.getId().contains("p1"));
+    assertEquals(DEFINITION.cardType(), card.getType());
+  }
+
+  // ── effect ───────────────────────────────────────────────────────
+
+  @Test
+  void execute_announcesEffectPublicly() {
+    CardCommandResult result = DEFINITION.execute(ctx());
+    assertTrue(result.getPublicMessage().contains("Alice"));
+    assertTrue(result.getPublicMessage().contains("Tunnel Chaos"));
+  }
+
+  @Test
+  void execute_hasNoPrivateResult() {
+    CardCommandResult result = DEFINITION.execute(ctx());
+    assertFalse(result.hasPrivateResult());
+  }
+
+  @Test
+  void execute_preservesDeckSize() {
+    int sizeBefore = game.getDeck().size();
+    DEFINITION.execute(ctx());
+    assertEquals(sizeBefore, game.getDeck().size());
+  }
+
+  @Test
+  void execute_keepsSameCards() {
+    List<String> idsBefore = deckCardIds();
+    DEFINITION.execute(ctx());
+    assertEquals(idsBefore, deckCardIds());
+  }
+
+  private List<String> deckCardIds() {
+    List<String> ids = new ArrayList<>(
+        game.getDeck().getCards().stream().map(Card::getId).toList());
+    Collections.sort(ids);
+    return ids;
+  }
+}


### PR DESCRIPTION
Adds the backend for the Tunnel Chaos card: activating it shuffles the draw deck and announces the effect to all players. The card has no target and no private result, so the generic activate flow (remove from hand, discard, broadcast) handles the rest.

* New TunnelChaosCardDefinition (@Component): execute() shuffles the live draw deck and returns a public-only message. Auto-registered via component scanning, so it joins each starting hand like the other command cards — no deck-composition change needed
* Tests cover the metadata, the testing card, and the effect: public message with the player name, no private result, deck size and contents preserved
* GameControllerTest: starting-hand size 15 → 16 and a new assertion that Tunnel Chaos is dealt with a stable id (tunnel_chaos_<playerId>) and name to every hand

Closes #57 