### PR TITLE
Squick cancel last action. Closes #67

### DIFF
--- a/src/main/java/com/doomhamsters/Board.java
+++ b/src/main/java/com/doomhamsters/Board.java
@@ -1,6 +1,7 @@
 package com.doomhamsters;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
@@ -22,6 +23,9 @@ public class Board {
   private int extraTurns;
   private boolean currentPlayerHasExtraTurns;
   private String restoredCurrentPlayerId;
+
+  @JsonIgnore
+  private LastActionSnapshot lastActionSnapshot;
 
   /**
    * Creates a board for the supplied players and deck.
@@ -59,6 +63,7 @@ public class Board {
     for (Card card : other.discardPile) {
       this.discardPile.add(new Card(card));
     }
+    this.lastActionSnapshot = null; // snapshots are transient; not carried into copies
   }
 
   /**
@@ -230,6 +235,33 @@ public class Board {
    */
   public boolean isCurrentPlayerHasExtraTurns() {
     return currentPlayerHasExtraTurns;
+  }
+
+  /**
+   * Records the game state before a card command runs so Squick can restore it.
+   *
+   * @param snapshot game state before the command ran
+   * @param commandId command id of the action being recorded
+   */
+  public void recordLastAction(Game snapshot, String commandId) {
+    this.lastActionSnapshot = new LastActionSnapshot(snapshot, commandId);
+  }
+
+  /**
+   * Returns the last recorded pre-command snapshot, or {@code null} if none exists.
+   *
+   * @return last action snapshot, or {@code null}
+   */
+  @JsonIgnore
+  public LastActionSnapshot getLastActionSnapshot() {
+    return lastActionSnapshot;
+  }
+
+  /**
+   * Clears the last action snapshot so it cannot be reused.
+   */
+  public void clearLastAction() {
+    this.lastActionSnapshot = null;
   }
 
   /**

--- a/src/main/java/com/doomhamsters/LastActionSnapshot.java
+++ b/src/main/java/com/doomhamsters/LastActionSnapshot.java
@@ -1,0 +1,42 @@
+package com.doomhamsters;
+
+/**
+ * A frozen copy of the game state taken just before a card command was executed.
+ *
+ * <p>Stored transiently on {@link Board}; never serialized or persisted.
+ * After a server restart there is no prior action to undo.
+ */
+public class LastActionSnapshot {
+
+  private final Game game;
+  private final String commandId;
+
+  /**
+   * Creates a snapshot.
+   *
+   * @param game      state of the game before the command ran; stored as a deep copy
+   * @param commandId command id of the action being recorded
+   */
+  public LastActionSnapshot(Game game, String commandId) {
+    this.game = new Game(game);
+    this.commandId = commandId;
+  }
+
+  /**
+   * Returns a defensive copy of the recorded game state.
+   *
+   * @return game state before the command ran
+   */
+  public Game getGame() {
+    return new Game(game);
+  }
+
+  /**
+   * Returns the command id of the action that was recorded.
+   *
+   * @return command id
+   */
+  public String getCommandId() {
+    return commandId;
+  }
+}

--- a/src/main/java/com/doomhamsters/gamesession/GameActionController.java
+++ b/src/main/java/com/doomhamsters/gamesession/GameActionController.java
@@ -102,6 +102,12 @@ public class GameActionController {
             request.getCommandId(),
             request.getCardType());
 
+    // Snapshot state before mutations so Squick can restore it.
+    // Squick itself is never recorded — it must not be undoable.
+    if (definition.isUndoable()) {
+      game.getBoard().recordLastAction(new Game(game), definition.commandId());
+    }
+
     Card playedCard = player.removeFromHand(request.getCardId());
     game.getBoard().discardCard(playedCard);
 

--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/CardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/CardDefinition.java
@@ -38,6 +38,17 @@ public interface CardDefinition extends CardCommand {
   }
 
   /**
+   * Returns whether this command can be undone by Squick.
+   *
+   * <p>All cards return {@code true} except Squick itself.
+   *
+   * @return {@code false} only for Squick
+   */
+  default boolean isUndoable() {
+    return true;
+  }
+
+  /**
    * Creates this card for a player's testing starting hand.
    *
    * @param playerId owning player id

--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/CardRegistry.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/CardRegistry.java
@@ -8,6 +8,7 @@ import com.doomhamsters.gamesession.cardcommands.cards.PowerNapCardDefinition;
 import com.doomhamsters.gamesession.cardcommands.cards.QuickPeekCardDefinition;
 import com.doomhamsters.gamesession.cardcommands.cards.SignOfFateCardDefinition;
 import com.doomhamsters.gamesession.cardcommands.cards.SniffAheadCardDefinition;
+import com.doomhamsters.gamesession.cardcommands.cards.SquickCardDefinition;
 import com.doomhamsters.gamesession.cardcommands.cards.StealCardDefinition;
 import com.doomhamsters.gamesession.dto.CardDto;
 import java.util.Collection;
@@ -67,10 +68,10 @@ public class CardRegistry {
         new SniffAheadCardDefinition(),
         new SignOfFateCardDefinition(),
         new StealCardDefinition(),
-        new QuickPeekCardDefinition(),
         new HamsterTrioCardDefinition(),
         new HyperModeCardDefinition(),
-        new BegForSnacksCardDefinition()
+        new BegForSnacksCardDefinition(),
+        new SquickCardDefinition()
     );
   }
 

--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/SquickCardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/SquickCardDefinition.java
@@ -1,0 +1,89 @@
+package com.doomhamsters.gamesession.cardcommands.cards;
+
+import com.doomhamsters.Card;
+import com.doomhamsters.Game;
+import com.doomhamsters.LastActionSnapshot;
+import com.doomhamsters.gamesession.cardcommands.CardCommandContext;
+import com.doomhamsters.gamesession.cardcommands.CardCommandResult;
+import com.doomhamsters.gamesession.cardcommands.CardDefinition;
+import org.springframework.stereotype.Component;
+
+/**
+ * Card definition for Squick.
+ *
+ * <p>Cancels the most recently executed card command by restoring the game state to the snapshot
+ * taken just before that command ran. All changes from the cancelled command — hand mutations,
+ * life changes, deck modifications — are fully reverted.
+ *
+ * <p>Constraints:
+ * <ul>
+ *   <li>Squick cannot cancel another Squick.
+ *   <li>Only one level of undo is available; the snapshot is consumed on use.
+ *   <li>The Squick card itself is removed from the restored state so the same effect
+ *       cannot be cancelled indefinitely.
+ * </ul>
+ */
+@Component
+public class SquickCardDefinition implements CardDefinition {
+
+  static final String COMMAND_ID = "SQUICK";
+
+  /** Required by Spring component scanning. */
+  public SquickCardDefinition() {}
+
+  @Override
+  public String cardType() {
+    return "Squick";
+  }
+
+  @Override
+  public String commandId() {
+    return COMMAND_ID;
+  }
+
+  @Override
+  public String displayName() {
+    return "Squick";
+  }
+
+  @Override
+  public boolean isUndoable() {
+    return false;
+  }
+
+  @Override
+  public Card createTestingCard(String playerId) {
+    return new Card("squick_" + playerId, displayName(), cardType());
+  }
+
+  @Override
+  public CardCommandResult execute(CardCommandContext context) {
+    LastActionSnapshot snapshot = context.getGame().getBoard().getLastActionSnapshot();
+
+    if (snapshot == null) {
+      throw new IllegalStateException("Squick: there is no card effect to cancel.");
+    }
+
+    if (COMMAND_ID.equalsIgnoreCase(snapshot.getCommandId())) {
+      throw new IllegalStateException("Squick: another Squick cannot be cancelled.");
+    }
+
+    // Prevent double-undo via a stale game reference held in the same request cycle.
+    context.getGame().getBoard().clearLastAction();
+
+    Game restored = snapshot.getGame();
+
+    // Remove the Squick card from the player's hand in the restored state so they cannot
+    // replay Squick to cancel the same effect again.
+    String squickCardId = context.getCard().getId();
+    restored.getPlayers().stream()
+        .filter(p -> p.getId().equals(context.getPlayer().getId()))
+        .findFirst()
+        .ifPresent(p -> p.removeFromHand(squickCardId));
+
+    context.getSession().setGame(restored);
+
+    return CardCommandResult.publicOnly(
+        context.getPlayer().getName() + " played Squick and cancelled the last card effect.");
+  }
+}

--- a/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
@@ -177,7 +177,7 @@ class GameControllerTest {
     assertEquals(31, testSession.getGame().getDeck().size());
     assertEquals(7, snackStashCardsInGame);
     testSession.getGame().getPlayers().forEach(player ->
-        assertEquals(18, player.getHand().size()));
+        assertEquals(19, player.getHand().size()));
   }
 
   @Test

--- a/src/test/java/com/doomhamsters/gamesession/cardcommands/cards/SquickCardDefinitionTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/cardcommands/cards/SquickCardDefinitionTest.java
@@ -1,0 +1,178 @@
+package com.doomhamsters.gamesession.cardcommands.cards;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.doomhamsters.Board;
+import com.doomhamsters.Card;
+import com.doomhamsters.Deck;
+import com.doomhamsters.Game;
+import com.doomhamsters.Player;
+import com.doomhamsters.gamesession.GameSession;
+import com.doomhamsters.gamesession.cardcommands.CardCommandContext;
+import com.doomhamsters.gamesession.cardcommands.CardCommandResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SquickCardDefinitionTest {
+
+  private static final SquickCardDefinition DEFINITION = new SquickCardDefinition();
+
+  private GameSession session;
+  private Game game;
+  private Player alice;
+  private Player bob;
+
+  @BeforeEach
+  void setUp() {
+    session = new GameSession("game-1", "lobby-1");
+    game = session.getGame();
+
+    game.setPlayers(List.of(new Player("p1", "Alice"), new Player("p2", "Bob")));
+    game.setDeck(new Deck());
+    game.setBoard(new Board(new ArrayList<>(game.getPlayers()), new Deck()));
+
+    alice = gamePlayer("p1");
+    bob = gamePlayer("p2");
+  }
+
+  // ── metadata ─────────────────────────────────────────────────────────────
+
+  @Test
+  void cardType_matchesExpected() {
+    assertEquals("Squick", DEFINITION.cardType());
+  }
+
+  @Test
+  void commandId_matchesExpected() {
+    assertEquals("SQUICK", DEFINITION.commandId());
+  }
+
+  @Test
+  void displayName_matchesExpected() {
+    assertEquals("Squick", DEFINITION.displayName());
+  }
+
+  @Test
+  void isUndoable_returnsFalse() {
+    assertFalse(DEFINITION.isUndoable());
+  }
+
+  @Test
+  void createTestingCard_containsPlayerId() {
+    Card card = DEFINITION.createTestingCard("p1");
+    assertTrue(card.getId().contains("p1"));
+    assertEquals(DEFINITION.cardType(), card.getType());
+  }
+
+  // ── happy path ───────────────────────────────────────────────────────────
+
+  @Test
+  void execute_restoresGameStateToBeforeLastCommand() {
+    // Bob gets a card that will be "stolen" by an effect
+    Card target = new Card("c1", "QuickPeek", "QuickPeek");
+    bob.addToHand(target);
+
+    // Snapshot the state before the effect runs (as the controller would)
+    game.getBoard().recordLastAction(new Game(game), "STEAL_CARD");
+
+    // Simulate the effect: card moved from Bob to Alice
+    bob.removeFromHand("c1");
+    alice.addToHand(target);
+    assertTrue(bob.getHand().isEmpty());
+    assertEquals(1, alice.getHand().size());
+
+    CardCommandResult result = DEFINITION.execute(ctx(alice));
+
+    assertTrue(result.getPublicMessage().contains("Alice"));
+    assertTrue(result.getPublicMessage().contains("cancelled the last card effect"));
+    assertFalse(result.hasPrivateResult());
+
+    // Restored game: Bob has his card back
+    Player restoredBob = restoredPlayer("p2");
+    assertEquals(1, restoredBob.getHand().size());
+    assertEquals("c1", restoredBob.getHand().get(0).getId());
+
+    // Restored game: Alice does not have the stolen card
+    Player restoredAlice = restoredPlayer("p1");
+    assertTrue(restoredAlice.getHand().stream().noneMatch(c -> c.getId().equals("c1")));
+  }
+
+  @Test
+  void execute_removesSquickFromRestoredHand_preventingInfiniteUndo() {
+    // Give Alice a Squick card and record it as existing before the effect
+    Card squick = new Card("sq_p1", DEFINITION.displayName(), DEFINITION.cardType());
+    alice.addToHand(squick);
+
+    // Snapshot (Squick is in Alice's hand at this point)
+    game.getBoard().recordLastAction(new Game(game), "TUNNEL_CHAOS");
+
+    // Simulate the effect (just some mutation)
+    game.getDeck().shuffle();
+
+    // Play Squick — use the same card id as the one in Alice's hand
+    CardCommandContext ctx = new CardCommandContext(
+        session, game, alice, squick, Map.of());
+    DEFINITION.execute(ctx);
+
+    // In the restored state, Alice should NOT still have the Squick card
+    Player restoredAlice = restoredPlayer("p1");
+    assertTrue(restoredAlice.getHand().stream().noneMatch(c -> c.getId().equals("sq_p1")));
+  }
+
+  @Test
+  void execute_snapshotIsConsumed_secondSquickThrows() {
+    game.getBoard().recordLastAction(new Game(game), "POWER_NAP");
+    DEFINITION.execute(ctx(alice));
+
+    // Snapshot was consumed; a second Squick on the restored game must fail
+    Game restoredGame = session.getGame();
+    CardCommandContext ctx2 = new CardCommandContext(
+        session, restoredGame, restoredPlayer("p1"),
+        new Card("sq2", DEFINITION.displayName(), DEFINITION.cardType()),
+        Map.of());
+
+    assertThrows(IllegalStateException.class, () -> DEFINITION.execute(ctx2));
+  }
+
+  // ── guard conditions ─────────────────────────────────────────────────────
+
+  @Test
+  void execute_throwsWhenNoSnapshotExists() {
+    // No recordLastAction call — snapshot is null
+    assertThrows(IllegalStateException.class, () -> DEFINITION.execute(ctx(alice)));
+  }
+
+  @Test
+  void execute_throwsWhenLastCommandWasAlsoSquick() {
+    game.getBoard().recordLastAction(new Game(game), "SQUICK");
+    assertThrows(IllegalStateException.class, () -> DEFINITION.execute(ctx(alice)));
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private Player gamePlayer(String id) {
+    return game.getPlayers().stream()
+        .filter(p -> p.getId().equals(id))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private Player restoredPlayer(String id) {
+    return session.getGame().getPlayers().stream()
+        .filter(p -> p.getId().equals(id))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private CardCommandContext ctx(Player player) {
+    Card squickCard = new Card(
+        "sq_" + player.getId(), DEFINITION.displayName(), DEFINITION.cardType());
+    return new CardCommandContext(session, game, player, squickCard, Map.of());
+  }
+}


### PR DESCRIPTION
 ## Summary

  - Adds a snapshot mechanism to `Board` that records the game state before each undoable card command, enabling one-level undo without persistence overhead (`@JsonIgnore` — transient per session).
  - Implements `SquickCardDefinition`: restores the game to its pre-last-action state, removes the Squick card from the restored hand to prevent infinite undo, and blocks cancelling another Squick.
  - Adds `isUndoable()` to `CardDefinition` (default `true`) so Squick opts out cleanly without touching every other definition.
  - Fixes a pre-existing duplicate `QuickPeekCardDefinition` entry in `CardRegistry.defaultRegistry()`.

  ## Test plan

  - [ ] `SquickCardDefinitionTest` — run all 7 tests: game state restored, Squick removed from restored hand, snapshot consumed after use, throws on no snapshot, throws when last command was also Squick
  - [ ] Existing `GameActionControllerTest` — all tests still pass (snapshot recording is a no-op side-effect for non-Squick paths)
  - [ ] Manual: play any card, then play Squick → confirm previous card effect reversed and Squick is gone from hand
  - [ ] Manual: play Squick as first action → confirm error event received
  - [ ] Manual: play Squick twice in a row → confirm second Squick rejected