### PR TITLE
Fix: force docker to pull latest image on every redeploy.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     # Pre-built image from GitHub Container Registry — built on every push to main via GitHub Actions
     # Deploy version: 3
     image: ghcr.io/se2-doomhamsters/server:latest
+    pull_policy: always
 
     # Restart automatically on crash; skip restart only if manually stopped
     restart: unless-stopped


### PR DESCRIPTION
Without pull_policy: always, Docker used the locally cached :latest image even when a newer version was available on ghcr.io, causing doco-cd to redeploy stale builds after every merge to main. That´s why the old container was never replaced by a newer one on the uni server. 