### PR TITLE
Add collectible hamster cards to the deck

### DIFF
--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/CardRegistry.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/CardRegistry.java
@@ -36,6 +36,10 @@ public class CardRegistry {
   private final Map<String, CardDefinition> definitionsByType;
   private final List<CardDefinition> definitions;
 
+  private static final List<String> HAMSTER_VARIANTS =
+      List.of("hamster_ninja", "hamster_viking", "hamster_wizard", "hamster_pirate");
+  private static final int HAMSTER_COPIES_PER_VARIANT = 4;
+
   /**
    * Creates the registry from discovered card definition beans.
    *
@@ -162,7 +166,30 @@ public class CardRegistry {
       }
     }
 
+    addHamsterCollectibleCards(cards);
+
     return cards;
+  }
+
+  /**
+   * Adds the collectible hamster cards that Hamster Combo commands consume.
+   *
+   * @param cards deck being built
+   */
+  private void addHamsterCollectibleCards(List<Card> cards) {
+    for (String variant : HAMSTER_VARIANTS) {
+      String displayName = toHamsterDisplayName(variant);
+      for (int copy = 0; copy < HAMSTER_COPIES_PER_VARIANT; copy++) {
+        cards.add(new Card(variant + "_" + copy, displayName, variant));
+      }
+    }
+  }
+
+  private String toHamsterDisplayName(String variant) {
+    String suffix = variant.substring(variant.indexOf('_') + 1);
+    String capitalized =
+        suffix.substring(0, 1).toUpperCase(Locale.ROOT) + suffix.substring(1);
+    return capitalized + " Hamster";
   }
 
   /**

--- a/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/GameControllerTest.java
@@ -175,7 +175,7 @@ class GameControllerTest {
             .filter(Card::isSnackStash)
             .count();
 
-    assertEquals(39, testSession.getGame().getDeck().size());
+    assertEquals(55, testSession.getGame().getDeck().size());
     assertEquals(3, snackStashCardsInGame);
     testSession.getGame().getPlayers().forEach(player ->
         assertEquals(6, player.getHand().size()));


### PR DESCRIPTION
The combo commands need matching hamster_* cards in hand, but createDeckCards only built the combo trigger cards, never the collectibles, so combos were impossible.

What changed:
- CardRegistry now adds 4 hamster variants (ninja, viking, wizard, pirate), 4 copies each, to every deck.
- Updated the deck size assertion in GameControllerTest from 39 to  55 to match

Closes #139 
