### PR TITLE
Bugfix/cardeffects

### DIFF
--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/BegForSnacksCardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/BegForSnacksCardDefinition.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class BegForSnacksCardDefinition extends AbstractCardDefinition {
 
   public BegForSnacksCardDefinition() {
-    super("BegForSnacks", "BegForSnacks", "Beg for Snacks");
+    super("BegForSnacks", "BEG_FOR_SNACKS", "Beg for Snacks");
   }
 
   @Override

--- a/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/BegForSnacksCardDefinition.java
+++ b/src/main/java/com/doomhamsters/gamesession/cardcommands/cards/BegForSnacksCardDefinition.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class BegForSnacksCardDefinition extends AbstractCardDefinition {
 
   public BegForSnacksCardDefinition() {
-    super("BegForSnacks", "BEG_FOR_SNACKS", "Beg for Snacks");
+    super("BegForSnacks", "BegForSnacks", "Beg for Snacks");
   }
 
   @Override

--- a/src/main/java/com/doomhamsters/gamesession/snackstash/SnackStashClaimService.java
+++ b/src/main/java/com/doomhamsters/gamesession/snackstash/SnackStashClaimService.java
@@ -4,7 +4,6 @@ import com.doomhamsters.Card;
 import com.doomhamsters.Game;
 import com.doomhamsters.Player;
 import com.doomhamsters.gamesession.GameSession;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -138,27 +137,13 @@ public class SnackStashClaimService {
       Player claimant,
       List<String> accusingPlayerIds) {
 
-    List<SnackStashLifeChange> lifeChanges = new ArrayList<>();
-    for (String playerId : accusingPlayerIds) {
-      Player voter = findPlayer(game, playerId);
-      int livesBefore = voter.getLives();
-      voter.decrementLives();
-      lifeChanges.add(
-          new SnackStashLifeChange(
-              voter.getId(),
-              voter.getName(),
-              livesBefore,
-              voter.getLives()));
-    }
     game.defusePendingDoomWithClaimedCard(claim.getCardId());
-    game.checkWinCondition();
 
     return SnackStashResolution.builder(SnackStashOutcome.LEGITIMATE_CALL, claim.getClaimId())
         .claimingPlayer(claimant.getId(), claimant.getName())
         .accusingPlayerIds(accusingPlayerIds)
-        .lifeChanges(lifeChanges)
         .doomDefused(true)
-        .message(claimant.getName() + " had a real Snack Stash. NO voters lose 1 life.")
+        .message(claimant.getName() + " had a real Snack Stash. Doom defused, no lives lost.")
         .build();
   }
 

--- a/src/main/java/com/doomhamsters/gamesession/snackstash/SnackStashWebSocketController.java
+++ b/src/main/java/com/doomhamsters/gamesession/snackstash/SnackStashWebSocketController.java
@@ -98,10 +98,14 @@ public class SnackStashWebSocketController {
             claimId,
             vote);
 
-    resolution.ifPresentOrElse(
-        resolved -> publishSnackStashResolutionEvent(session.getGameId(), resolved),
-        () -> publishSnackStashClaimProgressEvent(session));
-    gameSessionBroadcaster.saveAndBroadcast(session, playerId);
+    if (resolution.isPresent()) {
+      SnackStashResolution resolved = resolution.get();
+      publishSnackStashResolutionEvent(session.getGameId(), resolved);
+      gameSessionBroadcaster.saveAndBroadcast(session, resolved.getClaimingPlayerId());
+    } else {
+      publishSnackStashClaimProgressEvent(session);
+      gameSessionBroadcaster.saveAndBroadcast(session, playerId);
+    }
   }
 
   private GameSession loadSession(String gameId) {

--- a/src/test/java/com/doomhamsters/gamesession/snackstash/SnackStashClaimServiceTest.java
+++ b/src/test/java/com/doomhamsters/gamesession/snackstash/SnackStashClaimServiceTest.java
@@ -50,7 +50,7 @@ class SnackStashClaimServiceTest {
   }
 
   @Test
-  void noVotesAgainstRealSnackStashCostEachAccuserOneLife() {
+  void noVotesAgainstRealSnackStashDoNotCostAccuserLife() {
     GameSession session = runningSession(List.of("Alice", "Bob", "Cara"));
     Game game = session.getGame();
     Player claimant = game.getPlayers().get(0);
@@ -80,9 +80,9 @@ class SnackStashClaimServiceTest {
     SnackStashResolution resolution = resolved.orElseThrow();
     assertEquals(SnackStashOutcome.LEGITIMATE_CALL, resolution.getOutcome());
     assertEquals(List.of(firstVoter.getId(), secondVoter.getId()), resolution.getAccusingPlayerIds());
-    assertEquals(2, resolution.getLifeChanges().size());
-    assertEquals(firstLivesBefore - 1, firstVoter.getLives());
-    assertEquals(secondLivesBefore - 1, secondVoter.getLives());
+    assertTrue(resolution.getLifeChanges().isEmpty());
+    assertEquals(firstLivesBefore, firstVoter.getLives());
+    assertEquals(secondLivesBefore, secondVoter.getLives());
     assertTrue(game.isPendingDoomRequiresInsertion());
     assertNull(game.getPendingSnackStashClaim());
   }


### PR DESCRIPTION
Fix Snack Stash broadcast player perspective and remove false-challenge life penalty

After a Snack Stash vote resolves, the broadcast now uses the claiming player's ID instead of the voter's ID, so the doom-drawing player receives their correct hand and life state on their own device. Additionally, a LEGITIMATE_CALL outcome (real Snack Stash successfully challenged) no longer deducts a life from the challenger — doom is defused with no life consequence for any player. Test updated to reflect the new rule. 